### PR TITLE
Fix GitHub Actions and update URLs to cloudx-io organization

### DIFF
--- a/.github/workflows/core-release.yml
+++ b/.github/workflows/core-release.yml
@@ -91,7 +91,7 @@ pod 'CloudXCore', '~> $VERSION'
 
 ### Swift Package Manager
 \`\`\`
-https://github.com/cloudx-xenoss/cloudx-ios
+https://github.com/cloudx-io/cloudx-ios
 \`\`\`
 
 This release provides source-based distribution for easier integration and debugging." \

--- a/.github/workflows/meta-release.yml
+++ b/.github/workflows/meta-release.yml
@@ -82,7 +82,7 @@ jobs:
           sed -i '' "s/s\.version.*=.*/s.version = '$VERSION'/" CloudXMetaAdapter.podspec
           
           # Update Package.swift version and checksum
-          sed -i '' "s|url: \".*\"|url: \"https://github.com/cloudx-xenoss/cloudx-ios/releases/download/v$FULL_VERSION/CloudXMetaAdapter-v$VERSION.xcframework.zip\",|" Package.swift
+          sed -i '' "s|url: \".*\"|url: \"https://github.com/cloudx-io/cloudx-ios/releases/download/v$FULL_VERSION/CloudXMetaAdapter-v$VERSION.xcframework.zip\",|" Package.swift
           sed -i '' "s|checksum: \".*\"|checksum: \"${{ steps.checksum.outputs.checksum }}\"|" Package.swift
 
       - name: 🧪 Validate podspec
@@ -111,7 +111,7 @@ pod 'CloudXMetaAdapter', '~> $VERSION'
 
 ### Swift Package Manager
 \`\`\`
-https://github.com/cloudx-xenoss/cloudx-ios
+https://github.com/cloudx-io/cloudx-ios
 \`\`\`
 
 ### Manual Installation
@@ -125,7 +125,7 @@ Download \`CloudXMetaAdapter-v$VERSION.xcframework.zip\` from this release.
         run: |
           VERSION=${{ steps.version.outputs.version }}
           FULL_VERSION=${{ steps.version.outputs.full_version }}
-          ZIP_URL="https://github.com/cloudx-xenoss/cloudx-ios/releases/download/v$FULL_VERSION/CloudXMetaAdapter-v$VERSION.xcframework.zip"
+          ZIP_URL="https://github.com/cloudx-io/cloudx-ios/releases/download/v$FULL_VERSION/CloudXMetaAdapter-v$VERSION.xcframework.zip"
           echo "Waiting for $ZIP_URL to be fully available..."
 
           for i in {1..60}; do
@@ -147,7 +147,7 @@ Download \`CloudXMetaAdapter-v$VERSION.xcframework.zip\` from this release.
         run: |
           VERSION=${{ steps.version.outputs.version }}
           FULL_VERSION=${{ steps.version.outputs.full_version }}
-          ZIP_URL="https://github.com/cloudx-xenoss/cloudx-ios/releases/download/v$FULL_VERSION/CloudXMetaAdapter-v$VERSION.xcframework.zip"
+          ZIP_URL="https://github.com/cloudx-io/cloudx-ios/releases/download/v$FULL_VERSION/CloudXMetaAdapter-v$VERSION.xcframework.zip"
           echo "Waiting for $ZIP_URL to be downloadable using curl -fL..."
 
           for i in {1..30}; do

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ end
 
 Add this repository URL to your Xcode project:
 ```
-https://github.com/cloudx-xenoss/cloudx-ios
+https://github.com/cloudx-io/cloudx-ios
 ```
 
 ## Components

--- a/adapter-meta/CloudXMetaAdapter.podspec
+++ b/adapter-meta/CloudXMetaAdapter.podspec
@@ -3,14 +3,14 @@ Pod::Spec.new do |s|
   s.version = '1.1.25'
   s.summary = 'Mobile SDK for CloudX iOS Meta Adapter'
   s.description = 'iOS adapter add-on to the CloudX iOS SDK for a Meta bidder'
-  s.homepage = 'https://github.com/cloudx-xenoss/cloudx-ios'
+  s.homepage = 'https://github.com/cloudx-io/cloudx-ios'
   s.license = { :type => 'Proprietary', :text => 'Copyright 2024 CloudX, Inc. All rights reserved.' }
   s.authors = { 'CloudX' => 'support@cloudx.com' }
   s.platform = :ios, '14.0'
   s.module_name = 'CloudXMetaAdapter'
   s.static_framework = true
   s.source = {
-    :http => "https://github.com/cloudx-xenoss/cloudx-ios/releases/download/v#{s.version}-meta/CloudXMetaAdapter-v#{s.version}.xcframework.zip",
+    :http => "https://github.com/cloudx-io/cloudx-ios/releases/download/v#{s.version}-meta/CloudXMetaAdapter-v#{s.version}.xcframework.zip",
     :type => "zip",
     :flatten => false
   }

--- a/adapter-meta/Package.swift
+++ b/adapter-meta/Package.swift
@@ -13,12 +13,12 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/cloudx-xenoss/cloudx-ios.git", from: "1.1.40")
+        .package(url: "https://github.com/cloudx-io/cloudx-ios.git", from: "1.1.40")
     ],
     targets: [
         .binaryTarget(
             name: "CloudXMetaAdapter",
-            url: "https://github.com/cloudx-xenoss/cloudx-ios/releases/download/v1.1.25-meta/CloudXMetaAdapter-v1.1.25.xcframework.zip",
+            url: "https://github.com/cloudx-io/cloudx-ios/releases/download/v1.1.25-meta/CloudXMetaAdapter-v1.1.25.xcframework.zip",
             checksum: "1de4dffd27c735d59de48f2c8205cf209e2accc7ecf0cadcf70f14c9b60c068c"
         )
     ]

--- a/adapter-meta/README.md
+++ b/adapter-meta/README.md
@@ -29,14 +29,14 @@ pod install --repo-update
 
 Import the Swift Package into your XCode project via the following url
 ```bash
-https://github.com/cloudx-xenoss/cloudx-ios
+https://github.com/cloudx-io/cloudx-ios
 ```
 - ⚠️ Meta (FBAudienceNetwork) is **not available via Swift Package Manager**. You must manually download and integrate the **dynamic** (not static) framework.
 - FBAudienceNetwork manual installation instructions are found here [FBAudienceNetwork Installation Instructions](https://developers.facebook.com/docs/audience-network/setting-up/platform-setup/ios/add-sdk) 
 - NOTE: Follow the Project Configuration / Troubleshooting steps in the section below for additional setup setups
 
 ### 📦 Manual  
-1. Navigate to the releases and open the latest release (or whichever release you would like): [Releases](https://github.com/cloudx-xenoss/cloudx-ios/releases)  
+1. Navigate to the releases and open the latest release (or whichever release you would like): [Releases](https://github.com/cloudx-io/cloudx-ios/releases)  
 2. 📥 Download the `CloudXMetaAdapter-v{version}.xcframework.zip` file from the release  
 3. 🗂️ Unzip the download then drag and drop `CloudXMetaAdapter.xcframework` into your XCode project
 4. Follow the Project Configuration / Troubleshooting steps in the section below for additional setup setups

--- a/core/CloudXCore.podspec
+++ b/core/CloudXCore.podspec
@@ -3,10 +3,10 @@ Pod::Spec.new do |s|
   s.version          = '1.1.40'
   s.summary          = 'CloudX Core Framework'
   s.description      = 'Core framework for CloudX functionality'
-  s.homepage         = 'https://github.com/cloudx-xenoss/cloudx-ios'
+  s.homepage         = 'https://github.com/cloudx-io/cloudx-ios'
   s.license          = { :type => 'Business Source License 1.1', :file => 'core/LICENSE' }
   s.author           = { 'CloudX' => 'support@cloudx.io' }
-  s.source           = { :git => 'https://github.com/cloudx-xenoss/cloudx-ios.git', :tag => "v#{s.version}-core" }
+  s.source           = { :git => 'https://github.com/cloudx-io/cloudx-ios.git', :tag => "v#{s.version}-core" }
   
   s.ios.deployment_target = '14.0'
   

--- a/core/README.md
+++ b/core/README.md
@@ -49,13 +49,13 @@ pod install --repo-update
 ### Swift Package Manager
 
 1. In Xcode, go to **File** → **Add Package Dependencies**
-2. Enter the repository URL: `https://github.com/cloudx-xenoss/cloudx-ios`
+2. Enter the repository URL: `https://github.com/cloudx-io/cloudx-ios`
 3. Select the latest version and click **Add Package**
 4. Choose your target and click **Add Package**
 
 ### Manual Installation
 
-1. Download the latest release from [cloudx-ios Releases](https://github.com/cloudx-xenoss/cloudx-ios/releases)
+1. Download the latest release from [cloudx-ios Releases](https://github.com/cloudx-io/cloudx-ios/releases)
 2. Extract the downloaded zip file
 3. Drag the source files into your Xcode project
 4. Ensure "Copy items if needed" is checked and select your target
@@ -1272,8 +1272,8 @@ print("SDK Logs: \(logs)")
 
 ## Support
 
-- **Documentation**: [CloudX iOS Docs](https://github.com/cloudx-xenoss/cloudx-ios)
-- **Issues**: [GitHub Issues](https://github.com/cloudx-xenoss/cloudx-ios/issues)
+- **Documentation**: [CloudX iOS Docs](https://github.com/cloudx-io/cloudx-ios)
+- **Issues**: [GitHub Issues](https://github.com/cloudx-io/cloudx-ios/issues)
 - **Email**: eng@cloudx.io
 
 ## License


### PR DESCRIPTION
• Fixed YAML syntax errors in workflow release notes • Updated all URLs from cloudx-xenoss to cloudx-io organization • Fixed GitHub Actions workflow file paths and references • Updated podspecs and Package.swift for correct repository URLs • Ready for testing release workflows with cloudx-io org