### PR TITLE
Remove invalid --no-clean flag from pod trunk push

### DIFF
--- a/.github/workflows/core-release.yml
+++ b/.github/workflows/core-release.yml
@@ -65,7 +65,7 @@ jobs:
           cd core
 
           for i in {1..5}; do
-            pod trunk push CloudXCore.podspec --allow-warnings --skip-import-validation --skip-tests --no-clean && break
+            pod trunk push CloudXCore.podspec --allow-warnings --skip-import-validation --skip-tests && break
             echo "Pod trunk push failed. Retrying in 30 seconds... ($i/5)"
             sleep 30
           done


### PR DESCRIPTION
• --no-clean only works with pod spec lint, not pod trunk push • Keep --no-clean for validation step where it's needed • Fix trunk push command to use correct flags only