### PR TITLE
Fix: Remove authentication verification from Meta workflow

### DIFF
--- a/.github/workflows/meta-release.yml
+++ b/.github/workflows/meta-release.yml
@@ -162,79 +162,26 @@ jobs:
             exit 1
           }
 
-      - name: 🔐 Setup CocoaPods authentication
-        run: |
-          echo "=== Setting up CocoaPods authentication ==="
-          
-          # Clean any existing authentication
-          rm -rf ~/.cocoapods/trunk
-          
-          # Create fresh authentication directory and config
-          mkdir -p ~/.cocoapods/trunk
-          echo '{"trunk":{"token":"${{ secrets.COCOAPODS_TOKEN_NEW }}"}}' > ~/.cocoapods/trunk/me.json
-          
-          # Verify authentication with retry mechanism
-          echo "=== Verifying authentication ==="
-          for i in {1..3}; do
-            if pod trunk me; then
-              echo "✅ Authentication verified successfully"
-              break
-            else
-              echo "❌ Authentication verification failed (attempt $i/3)"
-              if [ $i -lt 3 ]; then
-                echo "Waiting 15 seconds before retry..."
-                sleep 15
-                # Recreate auth file in case it was corrupted
-                echo '{"trunk":{"token":"${{ secrets.COCOAPODS_TOKEN_NEW }}"}}' > ~/.cocoapods/trunk/me.json
-              else
-                echo "❌ Authentication setup failed after all retries"
-                exit 1
-              fi
-            fi
-          done
-
       - name: 📤 Push podspec to CocoaPods trunk
         run: |
+          # Setup authentication immediately before push (like Core workflow)
+          mkdir -p ~/.cocoapods/trunk
+          echo '{"trunk":{"token":"${{ secrets.COCOAPODS_TOKEN_NEW }}"}}' > ~/.cocoapods/trunk/me.json
           cd adapter-meta
-          echo "=== Starting CocoaPods trunk push ==="
-          echo "Current directory: $(pwd)"
-          
-          # Exponential backoff retry mechanism
-          RETRY_COUNT=0
-          MAX_RETRIES=6
-          BASE_DELAY=30
-          
-          while [ $RETRY_COUNT -lt $MAX_RETRIES ]; do
-            RETRY_COUNT=$((RETRY_COUNT + 1))
-            DELAY=$((BASE_DELAY * RETRY_COUNT))
-            
-            echo "=== Attempt $RETRY_COUNT/$MAX_RETRIES ==="
-            echo "Current authentication status:"
-            pod trunk me || echo "⚠️ Authentication issue detected"
-            
+
+          # Simple retry mechanism matching Core workflow pattern
+          for i in {1..5}; do
+            echo "=== Attempt $i/5 ==="
             if pod trunk push CloudXMetaAdapter.podspec --allow-warnings --skip-import-validation --skip-tests --verbose; then
-              echo "✅ Pod trunk push succeeded on attempt $RETRY_COUNT"
+              echo "✅ Pod trunk push succeeded on attempt $i"
               break
             else
-              echo "❌ Pod trunk push failed on attempt $RETRY_COUNT"
-              
-              if [ $RETRY_COUNT -lt $MAX_RETRIES ]; then
-                echo "Retrying in $DELAY seconds with exponential backoff..."
-                sleep $DELAY
-                
-                # Refresh authentication for next attempt
-                echo "Refreshing authentication..."
-                echo '{"trunk":{"token":"${{ secrets.COCOAPODS_TOKEN_NEW }}"}}' > ~/.cocoapods/trunk/me.json
+              echo "❌ Pod trunk push failed on attempt $i"
+              if [ $i -lt 5 ]; then
+                echo "Retrying in 30 seconds..."
+                sleep 30
               else
                 echo "❌ Pod trunk push failed after all retries"
-                echo "=== Final debug information ==="
-                echo "Working directory: $(pwd)"
-                echo "Files in current directory:"
-                ls -la
-                echo "CocoaPods trunk config:"
-                cat ~/.cocoapods/trunk/me.json || echo "No trunk config found"
-                echo "Pod environment:"
-                pod env
                 exit 1
               fi
             fi


### PR DESCRIPTION
## Problem
The Meta adapter workflow was failing due to CocoaPods authentication verification issues, while the Core workflow succeeds with the same token.

## Root Cause  
Analysis of the GitHub Actions UI logs revealed that:
- **Core workflow succeeds** on first attempt without pre-verification
- **Meta workflow fails** because it tries to verify authentication before using it
- The   - Name:     bryan
  - Email:    bryan@cloudx.io
  - Since:    March 27th, 12:39
  - Pods:
    - CloudXCore
    - CloudXMintegralAdapter
    - CloudXMetaAdapter
    - CloudXAdManagerAdapter
    - CloudXDemoAdapter
  - Sessions:
    - March 27th, 12:39     -        August 9th, 11:51. IP: 73.109.127.30
    - April 29th, 14:47     -      November 7th, 08:21. IP: 98.247.232.56  Description: macbook
    - July 2nd, 08:55       -      November 7th, 08:55. IP: 105.233.97.30  Description: CloudXCore CI
    - July 2nd, 08:56       -      December 4th, 03:17. IP: 105.233.97.30  Description: CloudXCore CI
    - July 10th, 01:02      -     November 15th, 01:02. IP: 154.68.164.125
    - July 10th, 01:05      -     November 15th, 01:07. IP: 154.68.164.125 Description: GitHub Actions token
    - July 10th, 01:07      -               Unverified. IP: 154.68.164.125
    - July 10th, 01:25      - January 30th, 2026 16:31. IP: 154.68.164.125 Description: meta-debug
    - September 24th, 16:32 - January 30th, 2026 16:33. IP: 98.246.158.18  Description: GitHub Actions token for cloudx-ios
    - September 24th, 16:37 - February 1st, 2026 14:15. IP: 98.246.158.18  Description: New token for cloudx-ios GitHub Actions
    - September 26th, 14:44 - February 1st, 2026 15:49. IP: 24.22.6.191 verification command fails, but the actual [32m
[!] No podspec found in directory `.`[0m
[!] Please specify the path to the podspec file.

Usage:

    $ pod trunk push [PATH]

      Publish the podspec at `PATH` to make it available to all users of the ‘trunk’
      spec-repo. If `PATH` is not provided, defaults to the current directory.

      Before pushing the podspec to cocoapods.org, this will perform a local lint of
      the podspec, including a build of the library. However, it remains *your*
      responsibility to ensure that the published podspec will actually work for your
      users. Thus it is recommended that you *first* try to use the podspec to
      integrate the library into your demo and/or real application.

      If this is the first time you publish a spec for this pod, you will
      automatically be registered as the ‘owner’ of this pod. (Note that ‘owner’ in
      this case implies a person that is allowed to publish new versions and add other
      ‘owners’, not necessarily the library author.)

Options:

    --allow-warnings           Allows push even if there are lint warnings
    --use-libraries            Linter uses static libraries to install the spec
    --use-modular-headers      Lint uses modular headers during installation
    --swift-version=VERSION    The SWIFT_VERSION that should be used to lint the spec.
                               This takes precedence over a .swift-version file.
    --skip-import-validation   Lint skips validating that the pod can be imported
    --skip-tests               Lint skips building and running tests during validation
    --synchronous              If validation depends on other recently pushed pods,
                               synchronize
    --allow-root               Allows CocoaPods to run as root
    --silent                   Show nothing
    --verbose                  Show more debugging information
    --no-ansi                  Show output without ANSI codes
    --help                     Show help banner of specified command works fine

## Solution
Simplify Meta workflow to match the **successful Core workflow pattern**:

### ✅ **Removed Complex Authentication**
- No more authentication verification step
- No more exponential backoff complexity  
- No more early authentication setup

### ✅ **Adopted Core Workflow Pattern**
- Setup authentication **immediately before push**
- Simple 5-attempt retry with 30-second delays
- Same exact structure that works for Core releases

### ✅ **Code Changes**
- Removed  step entirely
- Simplified  to match Core workflow
- Reduced complexity from 64 lines to 11 lines
- Maintained proper error handling and retry logic

## Expected Result
Meta adapter releases should now succeed using the same proven pattern that works reliably for Core adapter releases.

## Testing
Ready to test with next Meta adapter tag push.