### PR TITLE
Fix: Match Core workflow authentication pattern exactly

### DIFF
--- a/.github/workflows/meta-release.yml
+++ b/.github/workflows/meta-release.yml
@@ -13,7 +13,7 @@ jobs:
 
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TOKEN_NEW }}
+      COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
 
     steps:
       - name: 𝔠 Debug available Xcode versions
@@ -182,9 +182,12 @@ jobs:
           pod trunk info CloudXMetaAdapter || true
 
       - name: 📤 Push podspec to CocoaPods trunk
-        working-directory: adapter-meta
         run: |
-          # Use ONLY environment variable - no file conflicts
+          # Use EXACT same pattern as working Core workflow
+          mkdir -p ~/.cocoapods/trunk
+          echo '{"trunk":{"token":"${{ secrets.COCOAPODS_TOKEN_NEW }}"}}' > ~/.cocoapods/trunk/me.json
+          cd adapter-meta
+
           for i in {1..5}; do
             echo "=== Attempt $i/5 ==="
             if pod trunk push CloudXMetaAdapter.podspec --allow-warnings --skip-import-validation --skip-tests --verbose; then

--- a/.github/workflows/meta-release.yml
+++ b/.github/workflows/meta-release.yml
@@ -162,79 +162,26 @@ jobs:
             exit 1
           }
 
-      - name: 🔐 Setup CocoaPods authentication
-        run: |
-          echo "=== Setting up CocoaPods authentication ==="
-          
-          # Clean any existing authentication
-          rm -rf ~/.cocoapods/trunk
-          
-          # Create fresh authentication directory and config
-          mkdir -p ~/.cocoapods/trunk
-          echo '{"trunk":{"token":"${{ secrets.COCOAPODS_TOKEN_NEW }}"}}' > ~/.cocoapods/trunk/me.json
-          
-          # Verify authentication with retry mechanism
-          echo "=== Verifying authentication ==="
-          for i in {1..3}; do
-            if pod trunk me; then
-              echo "✅ Authentication verified successfully"
-              break
-            else
-              echo "❌ Authentication verification failed (attempt $i/3)"
-              if [ $i -lt 3 ]; then
-                echo "Waiting 15 seconds before retry..."
-                sleep 15
-                # Recreate auth file in case it was corrupted
-                echo '{"trunk":{"token":"${{ secrets.COCOAPODS_TOKEN_NEW }}"}}' > ~/.cocoapods/trunk/me.json
-              else
-                echo "❌ Authentication setup failed after all retries"
-                exit 1
-              fi
-            fi
-          done
-
       - name: 📤 Push podspec to CocoaPods trunk
         run: |
+          # Setup authentication immediately before push (like Core workflow)
+          mkdir -p ~/.cocoapods/trunk
+          echo '{"trunk":{"token":"${{ secrets.COCOAPODS_TOKEN_NEW }}"}}' > ~/.cocoapods/trunk/me.json
           cd adapter-meta
-          echo "=== Starting CocoaPods trunk push ==="
-          echo "Current directory: $(pwd)"
-          
-          # Exponential backoff retry mechanism
-          RETRY_COUNT=0
-          MAX_RETRIES=6
-          BASE_DELAY=30
-          
-          while [ $RETRY_COUNT -lt $MAX_RETRIES ]; do
-            RETRY_COUNT=$((RETRY_COUNT + 1))
-            DELAY=$((BASE_DELAY * RETRY_COUNT))
-            
-            echo "=== Attempt $RETRY_COUNT/$MAX_RETRIES ==="
-            echo "Current authentication status:"
-            pod trunk me || echo "⚠️ Authentication issue detected"
-            
+
+          # Simple retry mechanism matching Core workflow pattern
+          for i in {1..5}; do
+            echo "=== Attempt $i/5 ==="
             if pod trunk push CloudXMetaAdapter.podspec --allow-warnings --skip-import-validation --skip-tests --verbose; then
-              echo "✅ Pod trunk push succeeded on attempt $RETRY_COUNT"
+              echo "✅ Pod trunk push succeeded on attempt $i"
               break
             else
-              echo "❌ Pod trunk push failed on attempt $RETRY_COUNT"
-              
-              if [ $RETRY_COUNT -lt $MAX_RETRIES ]; then
-                echo "Retrying in $DELAY seconds with exponential backoff..."
-                sleep $DELAY
-                
-                # Refresh authentication for next attempt
-                echo "Refreshing authentication..."
-                echo '{"trunk":{"token":"${{ secrets.COCOAPODS_TOKEN_NEW }}"}}' > ~/.cocoapods/trunk/me.json
+              echo "❌ Pod trunk push failed on attempt $i"
+              if [ $i -lt 5 ]; then
+                echo "Retrying in 30 seconds..."
+                sleep 30
               else
                 echo "❌ Pod trunk push failed after all retries"
-                echo "=== Final debug information ==="
-                echo "Working directory: $(pwd)"
-                echo "Files in current directory:"
-                ls -la
-                echo "CocoaPods trunk config:"
-                cat ~/.cocoapods/trunk/me.json || echo "No trunk config found"
-                echo "Pod environment:"
-                pod env
                 exit 1
               fi
             fi


### PR DESCRIPTION
## Problem
Meta workflow still getting 401 errors despite token fixes. Need to match the **exact** authentication pattern that works for Core.

## Analysis
**Core workflow (WORKS):**
- Environment: `COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}`
- File: `${{ secrets.COCOAPODS_TOKEN_NEW }}` in me.json

**Meta workflow (FAILED):**
- Environment: `COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TOKEN_NEW }}`  
- File: None (trying env-only approach)

## Solution
**Use IDENTICAL authentication as Core:**
- Same environment variable mapping
- Same file-based token approach  
- Same nested JSON structure
- Same secret references

## Expected Result
Meta workflow should authenticate successfully using the proven Core pattern.