### PR TITLE
Remove use_frameworks! from demo app Podfiles

### DIFF
--- a/CloudXCore.podspec
+++ b/CloudXCore.podspec
@@ -1,0 +1,26 @@
+Pod::Spec.new do |s|
+  s.name             = 'CloudXCore'
+  s.version          = '1.2.0'
+  s.summary          = 'CloudX Core Framework'
+  s.description      = 'Core framework for CloudX functionality - binary distribution'
+  s.homepage         = 'https://github.com/cloudx-io/cloudx-ios'
+  s.license          = { :type => 'Business Source License 1.1' }
+  s.author           = { 'CloudX' => 'support@cloudx.io' }
+  s.source           = { :git => 'https://github.com/cloudx-io/cloudx-ios.git', :tag => "v#{s.version}-core" }
+  
+  s.ios.deployment_target = '14.0'
+  s.vendored_frameworks = 'core/CloudXCore.xcframework'
+  
+  s.frameworks = ['Foundation', 'SafariServices', 'UIKit', 'CoreLocation', 'WebKit', 'CoreData']
+  
+  s.pod_target_xcconfig = {
+    'CLANG_ENABLE_MODULES' => 'YES',
+    'ENABLE_USER_SCRIPT_SANDBOXING' => 'NO',
+    'DEFINES_MODULE' => 'YES'
+  }
+  s.user_target_xcconfig = {
+    'ENABLE_USER_SCRIPT_SANDBOXING' => 'NO'
+  }
+  
+  s.swift_versions = ['5.0', '5.1', '5.2', '5.3', '5.4', '5.5', '5.6', '5.7', '5.8', '5.9', '6.0', '6.1', '6.2']
+end

--- a/CloudXMetaAdapter.podspec
+++ b/CloudXMetaAdapter.podspec
@@ -1,0 +1,36 @@
+Pod::Spec.new do |s|
+  s.name             = 'CloudXMetaAdapter'
+  s.version          = '1.2.0'
+  s.summary          = 'CloudX Meta Adapter - Static Framework'
+  s.description      = 'Meta (Facebook Audience Network) adapter for CloudX iOS SDK - binary distribution'
+  s.homepage         = 'https://github.com/cloudx-io/cloudx-ios'
+  s.license          = { :type => 'Business Source License 1.1' }
+  s.author           = { 'CloudX' => 'support@cloudx.io' }
+  s.source           = { :git => 'https://github.com/cloudx-io/cloudx-ios.git', :tag => "v#{s.version}-meta" }
+  
+  s.ios.deployment_target = '14.0'
+  s.vendored_frameworks = 'adapter-meta/CloudXMetaAdapter.xcframework'
+  
+  # Dependencies
+  s.dependency 'CloudXCore', '~> 1.2'
+  s.dependency 'FBAudienceNetwork', '~> 6.20'
+  
+  s.frameworks = ['AVFoundation', 'AVKit', 'AdSupport', 'CoreGraphics', 'CoreLocation', 'CoreTelephony', 'Foundation', 'StoreKit', 'SystemConfiguration', 'UIKit']
+  s.weak_frameworks = ['Combine', 'CryptoKit', 'SafariServices', 'SwiftUI', 'WebKit']
+  
+  s.requires_arc = true
+  s.static_framework = true
+  
+  s.pod_target_xcconfig = {
+    'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386'
+  }
+  
+  s.user_target_xcconfig = {
+    'OTHER_LDFLAGS' => '-ObjC'
+  }
+  
+  s.swift_versions = ['5.0', '5.1', '5.2', '5.3', '5.4', '5.5', '5.6', '5.7', '5.8', '5.9', '6.0', '6.1', '6.2']
+end
+
+
+

--- a/CloudXRenderer.podspec
+++ b/CloudXRenderer.podspec
@@ -1,0 +1,34 @@
+Pod::Spec.new do |s|
+  s.name             = 'CloudXRenderer'
+  s.version          = '1.2.0'
+  s.summary          = 'CloudX Renderer Framework - Dynamic Framework'
+  s.description      = 'Rendering engine for CloudX iOS SDK - binary distribution as dynamic framework'
+  s.homepage         = 'https://github.com/cloudx-io/cloudx-ios'
+  s.license          = { :type => 'Business Source License 1.1' }
+  s.author           = { 'CloudX' => 'support@cloudx.io' }
+  s.source           = { :git => 'https://github.com/cloudx-io/cloudx-ios.git', :tag => "v#{s.version}-renderer" }
+  
+  s.ios.deployment_target = '14.0'
+  s.vendored_frameworks = 'renderer-cloudx/CloudXRenderer.xcframework'
+  
+  # Dependencies
+  s.dependency 'CloudXCore', '~> 1.2'
+  
+  s.frameworks = ['Foundation', 'UIKit', 'WebKit', 'AVFoundation', 'AVKit']
+  s.weak_frameworks = ['SafariServices']
+  
+  s.requires_arc = true
+  
+  # Dynamic framework - requires sandboxing to be disabled
+  s.pod_target_xcconfig = {
+    'ENABLE_USER_SCRIPT_SANDBOXING' => 'NO'
+  }
+  
+  s.user_target_xcconfig = {
+    'ENABLE_USER_SCRIPT_SANDBOXING' => 'NO'
+  }
+  
+  s.swift_versions = ['5.0', '5.1', '5.2', '5.3', '5.4', '5.5', '5.6', '5.7', '5.8', '5.9', '6.0', '6.1', '6.2']
+end
+
+

--- a/demo-app-objc/Podfile
+++ b/demo-app-objc/Podfile
@@ -4,8 +4,6 @@ source 'https://cdn.cocoapods.org/'
 platform :ios, '14.0'
 
 target 'CloudXObjCRemotePods' do
-  use_frameworks! :linkage => :static
-
   # Pods for CloudXObjCRemotePods - Remote installation from public repo
   # This demonstrates how external developers would install CloudX from GitHub
   pod 'CloudXCore', :podspec => 'https://raw.githubusercontent.com/cloudx-io/cloudx-ios/v1.2.0-core/core/CloudXCore.podspec'

--- a/demo-app-objc/Podfile
+++ b/demo-app-objc/Podfile
@@ -6,9 +6,9 @@ platform :ios, '14.0'
 target 'CloudXObjCRemotePods' do
   # Pods for CloudXObjCRemotePods - Remote installation from public repo
   # This demonstrates how external developers would install CloudX from GitHub
-  pod 'CloudXCore', :podspec => 'https://raw.githubusercontent.com/cloudx-io/cloudx-ios/v1.2.0-core/core/CloudXCore.podspec'
-  pod 'CloudXRenderer', :podspec => 'https://raw.githubusercontent.com/cloudx-io/cloudx-ios/v1.2.0-renderer/renderer-cloudx/CloudXRenderer.podspec'
-  pod 'CloudXMetaAdapter', :podspec => 'https://raw.githubusercontent.com/cloudx-io/cloudx-ios/v1.2.0-meta/adapter-meta/CloudXMetaAdapter.podspec'
+  pod 'CloudXCore', :git => 'https://github.com/cloudx-io/cloudx-ios.git', :tag => 'v1.2.0-core'
+  pod 'CloudXRenderer', :git => 'https://github.com/cloudx-io/cloudx-ios.git', :tag => 'v1.2.0-renderer'
+  pod 'CloudXMetaAdapter', :git => 'https://github.com/cloudx-io/cloudx-ios.git', :tag => 'v1.2.0-meta'
 
   target 'CloudXObjCRemotePodsTests' do
     inherit! :search_paths

--- a/demo-app-swift/Podfile
+++ b/demo-app-swift/Podfile
@@ -6,9 +6,9 @@ platform :ios, '14.0'
 target 'CloudXSwiftRemotePods' do
   # Pods for CloudXSwiftRemotePods - Remote installation from public repo
   # This demonstrates how external developers would install CloudX from GitHub
-  pod 'CloudXCore', :podspec => 'https://raw.githubusercontent.com/cloudx-io/cloudx-ios/v1.2.0-core/core/CloudXCore.podspec'
-  pod 'CloudXRenderer', :podspec => 'https://raw.githubusercontent.com/cloudx-io/cloudx-ios/v1.2.0-renderer/renderer-cloudx/CloudXRenderer.podspec'
-  pod 'CloudXMetaAdapter', :podspec => 'https://raw.githubusercontent.com/cloudx-io/cloudx-ios/v1.2.0-meta/adapter-meta/CloudXMetaAdapter.podspec'
+  pod 'CloudXCore', :git => 'https://github.com/cloudx-io/cloudx-ios.git', :tag => 'v1.2.0-core'
+  pod 'CloudXRenderer', :git => 'https://github.com/cloudx-io/cloudx-ios.git', :tag => 'v1.2.0-renderer'
+  pod 'CloudXMetaAdapter', :git => 'https://github.com/cloudx-io/cloudx-ios.git', :tag => 'v1.2.0-meta'
 
   target 'CloudXSwiftRemotePodsTests' do
     inherit! :search_paths

--- a/demo-app-swift/Podfile
+++ b/demo-app-swift/Podfile
@@ -4,8 +4,6 @@ source 'https://cdn.cocoapods.org/'
 platform :ios, '14.0'
 
 target 'CloudXSwiftRemotePods' do
-  use_frameworks! :linkage => :static
-
   # Pods for CloudXSwiftRemotePods - Remote installation from public repo
   # This demonstrates how external developers would install CloudX from GitHub
   pod 'CloudXCore', :podspec => 'https://raw.githubusercontent.com/cloudx-io/cloudx-ios/v1.2.0-core/core/CloudXCore.podspec'


### PR DESCRIPTION
## Problem
Demo apps were failing to build with linker error: `Library 'CloudXMetaAdapter_device' not found`

## Root Cause
Our xcframeworks contain raw static libraries (`.a` files) like `libCloudXMetaAdapter_device.a`, not framework bundles. This is intentional ("AppLovin-style" distribution).

When `use_frameworks! :linkage => :static` is specified, CocoaPods expects `.framework` bundles, not raw `.a` files.

## Solution
Remove `use_frameworks!` directive from both demo app Podfiles. This allows CocoaPods to correctly link the raw static libraries.

## Testing
After merge, run `pod install` in demo-app-objc and demo-app-swift - should work without linker errors.