### PR TITLE
Update demo apps to support setting ad listeners after creation

### DIFF
--- a/demo-app-objc/CloudXObjCRemotePods/Views/Ad/InterstitialViewController.m
+++ b/demo-app-objc/CloudXObjCRemotePods/Views/Ad/InterstitialViewController.m
@@ -110,8 +110,8 @@
         placement = _settings.interstitialPlacement;
     }
     
-    self.interstitialAd = [[CloudXCore shared] createInterstitialWithPlacement:placement
-                                                                        delegate:self];
+    self.interstitialAd = [[CloudXCore shared] createInterstitialWithPlacement:placement];
+    self.interstitialAd.delegate = self;
     
     // Note: The interstitial ad will internally preserve the original placement name through our CLXAd factory method updates
     

--- a/demo-app-objc/CloudXObjCRemotePods/Views/Ad/RewardedInterstitialViewController.m
+++ b/demo-app-objc/CloudXObjCRemotePods/Views/Ad/RewardedInterstitialViewController.m
@@ -90,8 +90,8 @@
     
     // Create rewarded interstitial with comprehensive logging
     NSLog(@"[RewardedInterstitialViewController] Calling createRewardedWithPlacement: %@", placement);
-    self.rewardedInterstitialAd = [[CloudXCore shared] createRewardedWithPlacement:placement
-                                                                          delegate:self];
+    self.rewardedInterstitialAd = [[CloudXCore shared] createRewardedWithPlacement:placement];
+    self.rewardedInterstitialAd.delegate = self;
     
     if (self.rewardedInterstitialAd) {
         NSLog(@"[RewardedInterstitialViewController] ✅ Rewarded interstitial ad instance created successfully: %@", self.rewardedInterstitialAd);

--- a/demo-app-objc/CloudXObjCRemotePods/Views/Ad/RewardedViewController.m
+++ b/demo-app-objc/CloudXObjCRemotePods/Views/Ad/RewardedViewController.m
@@ -110,8 +110,8 @@
     
     // Create rewarded with comprehensive logging
     NSLog(@"[RewardedViewController] Calling createRewardedWithPlacement: %@", placement);
-    self.rewardedAd = [[CloudXCore shared] createRewardedWithPlacement:placement
-                                                              delegate:self];
+    self.rewardedAd = [[CloudXCore shared] createRewardedWithPlacement:placement];
+    self.rewardedAd.delegate = self;
     
     if (self.rewardedAd) {
         NSLog(@"[RewardedViewController] ✅ Rewarded ad instance created successfully: %@", self.rewardedAd);
@@ -135,7 +135,8 @@
     NSString *placement = [self placementName];
     NSLog(@"[RewardedViewController] Creating new Rewarded ad instance with placement: %@", placement);
     // SDK config debugging removed to avoid undeclared selector warnings
-    self.rewardedAd = [[CloudXCore shared] createRewardedWithPlacement:placement delegate:self];
+    self.rewardedAd = [[CloudXCore shared] createRewardedWithPlacement:placement];
+    self.rewardedAd.delegate = self;
     if (self.rewardedAd) {
         NSLog(@"✅ Rewarded ad instance created successfully: %@", self.rewardedAd);
         [self startPollingReadyState];

--- a/demo-app-swift/CloudXSwiftRemotePods/AppDelegate.swift
+++ b/demo-app-swift/CloudXSwiftRemotePods/AppDelegate.swift
@@ -13,7 +13,7 @@ import AdSupport
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
     
-    var window: UIWindow? {
+    @objc var window: UIWindow? {
         // Fallback window for Meta SDK compatibility
         // In scene-based apps, the actual window is managed by SceneDelegate
         // but some SDKs still expect AppDelegate to have a window property

--- a/demo-app-swift/CloudXSwiftRemotePods/Views/Ad/InterstitialViewController.swift
+++ b/demo-app-swift/CloudXSwiftRemotePods/Views/Ad/InterstitialViewController.swift
@@ -91,7 +91,8 @@ class InterstitialViewController: BaseAdViewController {
             placement = settings.interstitialPlacement
         }
         
-        interstitialAd = cloudX.createInterstitial(placement: placement, delegate: self)
+        interstitialAd = cloudX.createInterstitial(placement: placement)
+        interstitialAd?.delegate = self
         
         if let interstitialAd = interstitialAd {
             interstitialAd.load()

--- a/demo-app-swift/CloudXSwiftRemotePods/Views/Ad/RewardedInterstitialViewController.swift
+++ b/demo-app-swift/CloudXSwiftRemotePods/Views/Ad/RewardedInterstitialViewController.swift
@@ -86,7 +86,8 @@ class RewardedInterstitialViewController: BaseAdViewController, CLXRewardedDeleg
         
         // Create rewarded interstitial with comprehensive logging
         DemoAppLogger.sharedInstance.logMessage("📱 [RewardedInterstitial] Calling createRewarded...")
-        rewardedInterstitialAd = CloudXCore.shared.createRewarded(placement: placement, delegate: self)
+        rewardedInterstitialAd = CloudXCore.shared.createRewarded(placement: placement)
+        rewardedInterstitialAd?.delegate = self
         
         if let rewardedInterstitialAd = rewardedInterstitialAd {
             DemoAppLogger.sharedInstance.logMessage("✅ [RewardedInterstitial] Rewarded interstitial ad instance created successfully")

--- a/demo-app-swift/CloudXSwiftRemotePods/Views/Ad/RewardedViewController.swift
+++ b/demo-app-swift/CloudXSwiftRemotePods/Views/Ad/RewardedViewController.swift
@@ -112,7 +112,8 @@ class RewardedViewController: BaseAdViewController, CLXRewardedDelegate {
         
         // Create rewarded with comprehensive logging
         DemoAppLogger.sharedInstance.logMessage("📱 [Rewarded] Calling createRewarded...")
-        rewardedAd = CloudXCore.shared.createRewarded(placement: placement, delegate: self)
+        rewardedAd = CloudXCore.shared.createRewarded(placement: placement)
+        rewardedAd?.delegate = self
         
         if let rewardedAd = rewardedAd {
             DemoAppLogger.sharedInstance.logMessage("✅ [Rewarded] Rewarded ad instance created successfully")


### PR DESCRIPTION
## Summary
Updates the demo apps to work with CloudXCore v1.2.0+ which allows setting ad listeners after ad object creation.

## Changes

### Demo Apps (ObjC & Swift)
- Updated interstitial, rewarded, and rewarded interstitial view controllers to set delegates after ad creation
- Fixed Swift AppDelegate `window` property visibility for ObjC interoperability (added `@objc` annotation)

## Usage Example
```objc
// New API pattern
self.interstitial = [CloudXCore.shared createInterstitialWithPlacement:@"placement"];
self.interstitial.delegate = self;
```

```swift
// Swift example
interstitialAd = cloudX.createInterstitial(placement: placement)
interstitialAd?.delegate = self
```

## Related PRs
- cloudx-ios-private #191: Core SDK API changes
- cloudx-flutter: iOS bridge updates + callback fixes  
- cloudx-react-native: iOS bridge updates