### PR TITLE
Update demo apps to use new banner API without tmax parameter

### DIFF
--- a/demo-app-objc/CloudXObjCRemotePods/Views/Ad/BannerViewController.m
+++ b/demo-app-objc/CloudXObjCRemotePods/Views/Ad/BannerViewController.m
@@ -184,8 +184,7 @@
     
     self.bannerAd = [[CloudXCore shared] createBannerWithPlacement:placement
                                                       viewController:self
-                                                          delegate:self
-                                                              tmax:nil];
+                                                          delegate:self];
     
     if (!self.bannerAd) {
         [self showAlertWithTitle:@"Error" message:@"Failed to create banner."];

--- a/demo-app-swift/CloudXSwiftRemotePods/Views/Ad/BannerViewController.swift
+++ b/demo-app-swift/CloudXSwiftRemotePods/Views/Ad/BannerViewController.swift
@@ -138,8 +138,7 @@ class BannerViewController: BaseAdViewController {
         let placement = CLXDemoConfigManager.sharedManager.currentConfig.bannerPlacement
         bannerAd = cloudX.createBanner(placement: placement, 
                                       viewController: self, 
-                                      delegate: self, 
-                                      tmax: nil)
+                                      delegate: self)
         
         if bannerAd == nil {
             DemoAppLogger.sharedInstance.logMessage("❌ Failed to create Banner ad instance")


### PR DESCRIPTION
- Remove tmax parameter from createBanner calls in ObjC demo
- Remove tmax parameter from createBanner calls in Swift demo
- Matches CloudXCore API change removing tmax from public banner method