### PR TITLE
Update demo apps for non-nil factory pattern

### DIFF
--- a/demo-app-objc/CloudXObjCRemotePods/Views/Ad/BannerViewController.m
+++ b/demo-app-objc/CloudXObjCRemotePods/Views/Ad/BannerViewController.m
@@ -186,11 +186,7 @@
                                                       viewController:self
                                                           delegate:self];
     
-    if (!self.bannerAd) {
-        [self showAlertWithTitle:@"Error" message:@"Failed to create banner."];
-        return;
-    }
-    
+    // SDK now always returns non-nil - validation errors deferred to load() callback
     // Add banner to view hierarchy immediately
     [self addBannerToViewHierarchy];
 }

--- a/demo-app-swift/CloudXSwiftRemotePods/Views/Ad/BannerViewController.swift
+++ b/demo-app-swift/CloudXSwiftRemotePods/Views/Ad/BannerViewController.swift
@@ -101,9 +101,8 @@ class BannerViewController: BaseAdViewController {
             createAndAddBannerToView()
         }
         
-        guard let bannerAd = bannerAd else {
-            return // Failed to create
-        }
+        // SDK now guarantees non-nil return from create methods
+        guard let bannerAd = bannerAd else { return }
         
         // Start loading
         isLoading = true
@@ -140,14 +139,11 @@ class BannerViewController: BaseAdViewController {
                                       viewController: self, 
                                       delegate: self)
         
-        if bannerAd == nil {
-            DemoAppLogger.sharedInstance.logMessage("❌ Failed to create Banner ad instance")
-            showAlert(title: "Error", message: "Failed to create Banner ad instance")
-        } else {
-            DemoAppLogger.sharedInstance.logMessage("✅ Banner ad instance created successfully")
-            // Add banner to view hierarchy immediately
-            addBannerToViewHierarchy()
-        }
+        // SDK now always returns non-nil - validation errors deferred to load() callback
+        DemoAppLogger.sharedInstance.logMessage("✅ Banner ad instance created successfully")
+        
+        // Add banner to view hierarchy immediately
+        addBannerToViewHierarchy()
     }
     
     private func addBannerToViewHierarchy() {


### PR DESCRIPTION
## Summary
Update Swift and ObjC demo apps to align with the core SDK refactor where create methods now always return non-nil instances.

## Changes

### Demo Apps Updated
- ✅ **Swift Demo App**: Removed dead nil checks after banner creation
- ✅ **ObjC Demo App**: Removed dead nil checks after banner creation  
- ✅ **Removed `tmax` parameter** from all `createBanner` API calls (previously merged in PR #10)

### Key Changes
1. **Removed dead code**: Create methods now always return non-nil, so nil checks are unnecessary
2. **Error handling**: Validation errors are now deferred to `load()` callback instead of returning nil
3. **Banner timeout**: Now managed internally by the SDK

## Before (Old Behavior)
```swift
bannerAd = cloudX.createBanner(placement: placement, 
                              viewController: self, 
                              delegate: self)

if bannerAd == nil {  // ❌ This check is now dead code
    showAlert(title: "Error", message: "Failed to create banner")
    return
}
```

## After (New Behavior)
```swift
bannerAd = cloudX.createBanner(placement: placement, 
                              viewController: self, 
                              delegate: self)

// ✅ SDK always returns non-nil - errors deferred to load() callback
// No nil check needed - errors will be reported via delegate
```

## Related PRs
- cloudx-ios-private (core SDK refactor): https://github.com/cloudx-io/cloudx-ios-private/pull/196
- cloudx-react-native (iOS bridge): No changes needed - already compatible

## Testing
- ✅ Swift demo app tested with Meta ads (staging)
- ✅ ObjC demo app tested with Vungle ads (production)
- ✅ Banner ads load and display correctly
- ✅ Errors properly reported through delegate callbacks
- ✅ No crashes or nil dereferences

## Breaking Changes
**None** - Demo apps updated to match new SDK behavior, but the public API contract remains compatible.

