### PR TITLE
feat: Update demo apps to new CLXAdDelegate API with CLXError

### DIFF
--- a/demo-app-objc/CloudXObjCRemotePods/Views/Ad/BannerViewController.m
+++ b/demo-app-objc/CloudXObjCRemotePods/Views/Ad/BannerViewController.m
@@ -262,8 +262,8 @@
 }
 
 #pragma mark - CLXBannerDelegate
-- (void)didLoadWithAd:(CLXAd *)ad {
-    [[DemoAppLogger sharedInstance] logAdEvent:@"✅ Banner didLoadWithAd" ad:ad];
+- (void)didLoadAd:(CLXAd *)ad {
+    [[DemoAppLogger sharedInstance] logAdEvent:@"✅ Banner didLoadAd" ad:ad];
     
     self.isLoading = NO;
     [self updateStatusUIWithState:AdStateReady];
@@ -271,8 +271,8 @@
     // Don't auto-show - user must press Show Banner button
 }
 
-- (void)failToLoadWithAd:(CLXAd *)ad error:(NSError *)error {
-    [[DemoAppLogger sharedInstance] logAdEvent:@"❌ Banner failToLoadWithAd" ad:ad];
+- (void)didFailToLoadAdWithError:(CLXError *)error {
+    [[DemoAppLogger sharedInstance] logMessage:[NSString stringWithFormat:@"❌ Banner failed to load - Error: %@", error ? error.localizedDescription : @"Unknown error"]];
     
     self.isLoading = NO;
     [self updateStatusUIWithState:AdStateNoAd];
@@ -284,12 +284,12 @@
     });
 }
 
-- (void)didShowWithAd:(CLXAd *)ad {
-    [[DemoAppLogger sharedInstance] logAdEvent:@"👀 Banner didShowWithAd" ad:ad];
+- (void)didDisplayAd:(CLXAd *)ad {
+    [[DemoAppLogger sharedInstance] logAdEvent:@"👀 Banner didDisplayAd" ad:ad];
 }
 
-- (void)failToShowWithAd:(CLXAd *)ad error:(NSError *)error {
-    [[DemoAppLogger sharedInstance] logAdEvent:@"❌ Banner failToShowWithAd" ad:ad];
+- (void)didFailToDisplayAd:(CLXAd *)ad error:(CLXError *)error {
+    [[DemoAppLogger sharedInstance] logAdEvent:@"❌ Banner didFailToDisplayAd" ad:ad];
     
     self.bannerAd = nil;
     
@@ -299,21 +299,21 @@
     });
 }
 
-- (void)didHideWithAd:(CLXAd *)ad {
-    [[DemoAppLogger sharedInstance] logAdEvent:@"🔚 Banner didHideWithAd" ad:ad];
+- (void)didHideAd:(CLXAd *)ad {
+    [[DemoAppLogger sharedInstance] logAdEvent:@"🔚 Banner didHideAd" ad:ad];
     self.bannerAd = nil;
 }
 
-- (void)didClickWithAd:(CLXAd *)ad {
-    [[DemoAppLogger sharedInstance] logAdEvent:@"👆 Banner didClickWithAd" ad:ad];
+- (void)didClickAd:(CLXAd *)ad {
+    [[DemoAppLogger sharedInstance] logAdEvent:@"👆 Banner didClickAd" ad:ad];
 }
 
-- (void)impressionOn:(CLXAd *)ad {
-    [[DemoAppLogger sharedInstance] logAdEvent:@"👁️ Banner impressionOn" ad:ad];
+- (void)didRecordImpressionForAd:(CLXAd *)ad {
+    [[DemoAppLogger sharedInstance] logAdEvent:@"👁️ Banner didRecordImpressionForAd" ad:ad];
 }
 
-- (void)revenuePaid:(CLXAd *)ad {
-    [[DemoAppLogger sharedInstance] logAdEvent:@"💰 Banner revenuePaid" ad:ad];
+- (void)didPayRevenueForAd:(CLXAd *)ad {
+    [[DemoAppLogger sharedInstance] logAdEvent:@"💰 Banner didPayRevenueForAd" ad:ad];
 }
 
 // NEW MAX SDK Compatibility Delegate Methods

--- a/demo-app-objc/CloudXObjCRemotePods/Views/Ad/InterstitialViewController.m
+++ b/demo-app-objc/CloudXObjCRemotePods/Views/Ad/InterstitialViewController.m
@@ -153,14 +153,14 @@
 
 #pragma mark - CLXInterstitialDelegate
 
-- (void)didLoadWithAd:(CLXAd *)ad {
-    [[DemoAppLogger sharedInstance] logAdEvent:@"✅ Interstitial didLoadWithAd" ad:ad];
+- (void)didLoadAd:(CLXAd *)ad {
+    [[DemoAppLogger sharedInstance] logAdEvent:@"✅ Interstitial didLoadAd" ad:ad];
     self.isLoading = NO;
     [self updateStatusUIWithState:AdStateReady];
 }
 
-- (void)failToLoadWithAd:(CLXAd *)ad error:(NSError *)error {
-    [[DemoAppLogger sharedInstance] logAdEvent:@"❌ Interstitial failToLoadWithAd" ad:ad];
+- (void)didFailToLoadAdWithError:(CLXError *)error {
+    [[DemoAppLogger sharedInstance] logMessage:[NSString stringWithFormat:@"❌ Interstitial failed to load - Error: %@", error ? error.localizedDescription : @"Unknown error"]];
     self.isLoading = NO;
     [self updateStatusUIWithState:AdStateNoAd];
     
@@ -171,12 +171,12 @@
     });
 }
 
-- (void)didShowWithAd:(CLXAd *)ad {
-    [[DemoAppLogger sharedInstance] logAdEvent:@"👀 Interstitial didShowWithAd" ad:ad];
+- (void)didDisplayAd:(CLXAd *)ad {
+    [[DemoAppLogger sharedInstance] logAdEvent:@"👀 Interstitial didDisplayAd" ad:ad];
 }
 
-- (void)failToShowWithAd:(CLXAd *)ad error:(NSError *)error {
-    [[DemoAppLogger sharedInstance] logAdEvent:@"❌ Interstitial failToShowWithAd" ad:ad];
+- (void)didFailToDisplayAd:(CLXAd *)ad error:(CLXError *)error {
+    [[DemoAppLogger sharedInstance] logAdEvent:@"❌ Interstitial didFailToDisplayAd" ad:ad];
     [self updateStatusUIWithState:AdStateNoAd];
     
     dispatch_async(dispatch_get_main_queue(), ^{
@@ -186,8 +186,8 @@
     });
 }
 
-- (void)didHideWithAd:(CLXAd *)ad {
-    [[DemoAppLogger sharedInstance] logAdEvent:@"🔚 Interstitial didHideWithAd" ad:ad];
+- (void)didHideAd:(CLXAd *)ad {
+    [[DemoAppLogger sharedInstance] logAdEvent:@"🔚 Interstitial didHideAd" ad:ad];
     
     self.showAdWhenLoaded = NO;
     self.interstitialAd = nil;
@@ -196,16 +196,16 @@
     [self updateStatusUIWithState:AdStateNoAd];
 }
 
-- (void)didClickWithAd:(CLXAd *)ad {
-    [[DemoAppLogger sharedInstance] logAdEvent:@"👆 Interstitial didClickWithAd" ad:ad];
+- (void)didClickAd:(CLXAd *)ad {
+    [[DemoAppLogger sharedInstance] logAdEvent:@"👆 Interstitial didClickAd" ad:ad];
 }
 
-- (void)impressionOn:(CLXAd *)ad {
-    [[DemoAppLogger sharedInstance] logAdEvent:@"👁️ Interstitial impressionOn" ad:ad];
+- (void)didRecordImpressionForAd:(CLXAd *)ad {
+    [[DemoAppLogger sharedInstance] logAdEvent:@"👁️ Interstitial didRecordImpressionForAd" ad:ad];
 }
 
-- (void)revenuePaid:(CLXAd *)ad {
-    [[DemoAppLogger sharedInstance] logAdEvent:@"💰 Interstitial revenuePaid" ad:ad];
+- (void)didPayRevenueForAd:(CLXAd *)ad {
+    [[DemoAppLogger sharedInstance] logAdEvent:@"💰 Interstitial didPayRevenueForAd" ad:ad];
 }
 
 @end 

--- a/demo-app-objc/CloudXObjCRemotePods/Views/Ad/MRECViewController.m
+++ b/demo-app-objc/CloudXObjCRemotePods/Views/Ad/MRECViewController.m
@@ -176,16 +176,16 @@
 
 #pragma mark - CLXBannerDelegate
 
-- (void)didLoadWithAd:(CLXAd *)ad {
-    [[DemoAppLogger sharedInstance] logAdEvent:@"✅ MREC didLoadWithAd" ad:ad];
+- (void)didLoadAd:(CLXAd *)ad {
+    [[DemoAppLogger sharedInstance] logAdEvent:@"✅ MREC didLoadAd" ad:ad];
     self.isLoading = NO;
     [self updateStatusUIWithState:AdStateReady];
     
     // Don't auto-show - user must press Show MREC button
 }
 
-- (void)failToLoadWithAd:(CLXAd *)ad error:(NSError *)error {
-    [[DemoAppLogger sharedInstance] logAdEvent:@"❌ MREC failToLoadWithAd" ad:ad];
+- (void)didFailToLoadAdWithError:(CLXError *)error {
+    [[DemoAppLogger sharedInstance] logMessage:[NSString stringWithFormat:@"❌ MREC failed to load - Error: %@", error ? error.localizedDescription : @"Unknown error"]];
     self.isLoading = NO;
     
     dispatch_async(dispatch_get_main_queue(), ^{
@@ -194,12 +194,12 @@
     });
 }
 
-- (void)didShowWithAd:(CLXAd *)ad {
-    [[DemoAppLogger sharedInstance] logAdEvent:@"👀 MREC didShowWithAd" ad:ad];
+- (void)didDisplayAd:(CLXAd *)ad {
+    [[DemoAppLogger sharedInstance] logAdEvent:@"👀 MREC didDisplayAd" ad:ad];
 }
 
-- (void)failToShowWithAd:(CLXAd *)ad error:(NSError *)error {
-    [[DemoAppLogger sharedInstance] logAdEvent:@"❌ MREC failToShowWithAd" ad:ad];
+- (void)didFailToDisplayAd:(CLXAd *)ad error:(CLXError *)error {
+    [[DemoAppLogger sharedInstance] logAdEvent:@"❌ MREC didFailToDisplayAd" ad:ad];
     
     dispatch_async(dispatch_get_main_queue(), ^{
         NSString *errorMessage = error ? [error detailedDemoDescription] : @"Unknown error occurred";
@@ -207,21 +207,21 @@
     });
 }
 
-- (void)didHideWithAd:(CLXAd *)ad {
-    [[DemoAppLogger sharedInstance] logAdEvent:@"🔚 MREC didHideWithAd" ad:ad];
+- (void)didHideAd:(CLXAd *)ad {
+    [[DemoAppLogger sharedInstance] logAdEvent:@"🔚 MREC didHideAd" ad:ad];
     self.mrecAd = nil;
 }
 
-- (void)didClickWithAd:(CLXAd *)ad {
-    [[DemoAppLogger sharedInstance] logAdEvent:@"👆 MREC didClickWithAd" ad:ad];
+- (void)didClickAd:(CLXAd *)ad {
+    [[DemoAppLogger sharedInstance] logAdEvent:@"👆 MREC didClickAd" ad:ad];
 }
 
-- (void)impressionOn:(CLXAd *)ad {
-    [[DemoAppLogger sharedInstance] logAdEvent:@"👁️ MREC impressionOn" ad:ad];
+- (void)didRecordImpressionForAd:(CLXAd *)ad {
+    [[DemoAppLogger sharedInstance] logAdEvent:@"👁️ MREC didRecordImpressionForAd" ad:ad];
 }
 
-- (void)revenuePaid:(CLXAd *)ad {
-    [[DemoAppLogger sharedInstance] logAdEvent:@"💰 MREC revenuePaid" ad:ad];
+- (void)didPayRevenueForAd:(CLXAd *)ad {
+    [[DemoAppLogger sharedInstance] logAdEvent:@"💰 MREC didPayRevenueForAd" ad:ad];
 }
 
 // Banner-specific delegate methods (MREC is a banner type)

--- a/demo-app-objc/CloudXObjCRemotePods/Views/Ad/NativeBannerViewController.m
+++ b/demo-app-objc/CloudXObjCRemotePods/Views/Ad/NativeBannerViewController.m
@@ -173,15 +173,15 @@
 
 #pragma mark - CLXNativeDelegate
 
-- (void)didLoadWithAd:(CLXAd *)ad {
-    [[DemoAppLogger sharedInstance] logAdEvent:@"✅ NativeBanner didLoadWithAd" ad:ad];
+- (void)didLoadAd:(CLXAd *)ad {
+    [[DemoAppLogger sharedInstance] logAdEvent:@"✅ NativeBanner didLoadAd" ad:ad];
     dispatch_async(dispatch_get_main_queue(), ^{
         [self updateStatusUIWithState:AdStateReady];
     });
 }
 
-- (void)failToLoadWithAd:(CLXAd *)ad error:(NSError *)error {
-    [[DemoAppLogger sharedInstance] logMessage:[NSString stringWithFormat:@"❌ NativeBanner failToLoadWithAd - Error: %@", error.localizedDescription]];
+- (void)didFailToLoadAdWithError:(CLXError *)error {
+    [[DemoAppLogger sharedInstance] logMessage:[NSString stringWithFormat:@"❌ NativeBanner failed to load - Error: %@", error.localizedDescription]];
     
     dispatch_async(dispatch_get_main_queue(), ^{
         self.nativeBannerAd = nil;
@@ -190,12 +190,12 @@
     });
 }
 
-- (void)didShowWithAd:(CLXAd *)ad {
-    [[DemoAppLogger sharedInstance] logAdEvent:@"👀 NativeBanner didShowWithAd" ad:ad];
+- (void)didDisplayAd:(CLXAd *)ad {
+    [[DemoAppLogger sharedInstance] logAdEvent:@"👀 NativeBanner didDisplayAd" ad:ad];
 }
 
-- (void)failToShowWithAd:(CLXAd *)ad error:(NSError *)error {
-    [[DemoAppLogger sharedInstance] logMessage:[NSString stringWithFormat:@"❌ NativeBanner failToShowWithAd - Error: %@", error.localizedDescription]];
+- (void)didFailToDisplayAd:(CLXAd *)ad error:(CLXError *)error {
+    [[DemoAppLogger sharedInstance] logMessage:[NSString stringWithFormat:@"❌ NativeBanner didFailToDisplayAd - Error: %@", error.localizedDescription]];
     
     dispatch_async(dispatch_get_main_queue(), ^{
         self.nativeBannerAd = nil;
@@ -204,21 +204,21 @@
     });
 }
 
-- (void)didHideWithAd:(CLXAd *)ad {
-    [[DemoAppLogger sharedInstance] logMessage:[NSString stringWithFormat:@"🔚 NativeBanner didHideWithAd - Ad: %@", ad]];
+- (void)didHideAd:(CLXAd *)ad {
+    [[DemoAppLogger sharedInstance] logMessage:[NSString stringWithFormat:@"🔚 NativeBanner didHideAd - Ad: %@", ad]];
     self.nativeBannerAd = nil;
 }
 
-- (void)didClickWithAd:(CLXAd *)ad {
-    [[DemoAppLogger sharedInstance] logMessage:[NSString stringWithFormat:@"👆 NativeBanner didClickWithAd - Ad: %@", ad]];
+- (void)didClickAd:(CLXAd *)ad {
+    [[DemoAppLogger sharedInstance] logMessage:[NSString stringWithFormat:@"👆 NativeBanner didClickAd - Ad: %@", ad]];
 }
 
-- (void)impressionOn:(CLXAd *)ad {
-    [[DemoAppLogger sharedInstance] logAdEvent:@"👁️ NativeBanner impressionOn" ad:ad];
+- (void)didRecordImpressionForAd:(CLXAd *)ad {
+    [[DemoAppLogger sharedInstance] logAdEvent:@"👁️ NativeBanner didRecordImpressionForAd" ad:ad];
 }
 
-- (void)revenuePaid:(CLXAd *)ad {
-    [[DemoAppLogger sharedInstance] logAdEvent:@"💰 NativeBanner revenuePaid" ad:ad];
+- (void)didPayRevenueForAd:(CLXAd *)ad {
+    [[DemoAppLogger sharedInstance] logAdEvent:@"💰 NativeBanner didPayRevenueForAd" ad:ad];
 }
 
 @end

--- a/demo-app-objc/CloudXObjCRemotePods/Views/Ad/NativeViewController.m
+++ b/demo-app-objc/CloudXObjCRemotePods/Views/Ad/NativeViewController.m
@@ -160,8 +160,8 @@
 
 #pragma mark - CLXNativeDelegate
 
-- (void)didLoadWithAd:(CLXAd *)ad {
-    [[DemoAppLogger sharedInstance] logAdEvent:@"✅ Native didLoadWithAd" ad:ad];
+- (void)didLoadAd:(CLXAd *)ad {
+    [[DemoAppLogger sharedInstance] logAdEvent:@"✅ Native didLoadAd" ad:ad];
     dispatch_async(dispatch_get_main_queue(), ^{
         self.isLoading = NO;
         [self updateStatusUIWithState:AdStateReady];
@@ -170,8 +170,8 @@
     // Don't auto-show - user must press Show Native button
 }
 
-- (void)failToLoadWithAd:(CLXAd *)ad error:(NSError *)error {
-    [[DemoAppLogger sharedInstance] logAdEvent:@"❌ Native failToLoadWithAd" ad:ad];
+- (void)didFailToLoadAdWithError:(CLXError *)error {
+    [[DemoAppLogger sharedInstance] logMessage:[NSString stringWithFormat:@"❌ Native failed to load - Error: %@", error ? error.localizedDescription : @"Unknown error"]];
     
     dispatch_async(dispatch_get_main_queue(), ^{
         self.nativeAd = nil;
@@ -180,12 +180,12 @@
     });
 }
 
-- (void)didShowWithAd:(CLXAd *)ad {
-    [[DemoAppLogger sharedInstance] logAdEvent:@"👀 Native didShowWithAd" ad:ad];
+- (void)didDisplayAd:(CLXAd *)ad {
+    [[DemoAppLogger sharedInstance] logAdEvent:@"👀 Native didDisplayAd" ad:ad];
 }
 
-- (void)failToShowWithAd:(CLXAd *)ad error:(NSError *)error {
-    [[DemoAppLogger sharedInstance] logAdEvent:@"❌ Native failToShowWithAd" ad:ad];
+- (void)didFailToDisplayAd:(CLXAd *)ad error:(CLXError *)error {
+    [[DemoAppLogger sharedInstance] logAdEvent:@"❌ Native didFailToDisplayAd" ad:ad];
     
     dispatch_async(dispatch_get_main_queue(), ^{
         self.nativeAd = nil;
@@ -194,21 +194,21 @@
     });
 }
 
-- (void)didHideWithAd:(CLXAd *)ad {
-    [[DemoAppLogger sharedInstance] logAdEvent:@"🔚 Native didHideWithAd" ad:ad];
+- (void)didHideAd:(CLXAd *)ad {
+    [[DemoAppLogger sharedInstance] logAdEvent:@"🔚 Native didHideAd" ad:ad];
     self.nativeAd = nil;
 }
 
-- (void)didClickWithAd:(CLXAd *)ad {
-    [[DemoAppLogger sharedInstance] logAdEvent:@"👆 Native didClickWithAd" ad:ad];
+- (void)didClickAd:(CLXAd *)ad {
+    [[DemoAppLogger sharedInstance] logAdEvent:@"👆 Native didClickAd" ad:ad];
 }
 
-- (void)impressionOn:(CLXAd *)ad {
-    [[DemoAppLogger sharedInstance] logAdEvent:@"👁️ Native impressionOn" ad:ad];
+- (void)didRecordImpressionForAd:(CLXAd *)ad {
+    [[DemoAppLogger sharedInstance] logAdEvent:@"👁️ Native didRecordImpressionForAd" ad:ad];
 }
 
-- (void)revenuePaid:(CLXAd *)ad {
-    [[DemoAppLogger sharedInstance] logAdEvent:@"💰 Native revenuePaid" ad:ad];
+- (void)didPayRevenueForAd:(CLXAd *)ad {
+    [[DemoAppLogger sharedInstance] logAdEvent:@"💰 Native didPayRevenueForAd" ad:ad];
 }
 
 @end 

--- a/demo-app-objc/CloudXObjCRemotePods/Views/Ad/RewardedInterstitialViewController.m
+++ b/demo-app-objc/CloudXObjCRemotePods/Views/Ad/RewardedInterstitialViewController.m
@@ -133,14 +133,14 @@
 
 #pragma mark - CLXRewardedInterstitialDelegate
 
-- (void)didLoadWithAd:(CLXAd *)ad {
-    [[DemoAppLogger sharedInstance] logMessage:[NSString stringWithFormat:@"✅ RewardedInterstitial didLoadWithAd - Ad: %@", ad]];
+- (void)didLoadAd:(CLXAd *)ad {
+    [[DemoAppLogger sharedInstance] logMessage:[NSString stringWithFormat:@"✅ RewardedInterstitial didLoadAd - Ad: %@", ad]];
     self.isLoading = NO;
     [self updateStatusUIWithState:AdStateReady];
 }
 
-- (void)failToLoadWithAd:(CLXAd *)ad error:(NSError *)error {
-    [[DemoAppLogger sharedInstance] logMessage:[NSString stringWithFormat:@"❌ RewardedInterstitial failToLoadWithAd - Error: %@", error.localizedDescription]];
+- (void)didFailToLoadAdWithError:(CLXError *)error {
+    [[DemoAppLogger sharedInstance] logMessage:[NSString stringWithFormat:@"❌ RewardedInterstitial failed to load - Error: %@", error.localizedDescription]];
     self.isLoading = NO;
     [self updateStatusUIWithState:AdStateNoAd];
     
@@ -152,12 +152,12 @@
     });
 }
 
-- (void)didShowWithAd:(CLXAd *)ad {
-    [[DemoAppLogger sharedInstance] logMessage:[NSString stringWithFormat:@"👀 RewardedInterstitial didShowWithAd - Ad: %@", ad]];
+- (void)didDisplayAd:(CLXAd *)ad {
+    [[DemoAppLogger sharedInstance] logMessage:[NSString stringWithFormat:@"👀 RewardedInterstitial didDisplayAd - Ad: %@", ad]];
 }
 
-- (void)failToShowWithAd:(CLXAd *)ad error:(NSError *)error {
-    [[DemoAppLogger sharedInstance] logMessage:[NSString stringWithFormat:@"❌ RewardedInterstitial failToShowWithAd - Error: %@", error.localizedDescription]];
+- (void)didFailToDisplayAd:(CLXAd *)ad error:(CLXError *)error {
+    [[DemoAppLogger sharedInstance] logMessage:[NSString stringWithFormat:@"❌ RewardedInterstitial didFailToDisplayAd - Error: %@", error.localizedDescription]];
     [self updateStatusUIWithState:AdStateNoAd];
     
     dispatch_async(dispatch_get_main_queue(), ^{
@@ -168,23 +168,23 @@
     });
 }
 
-- (void)didHideWithAd:(CLXAd *)ad {
-    [[DemoAppLogger sharedInstance] logMessage:[NSString stringWithFormat:@"🔚 RewardedInterstitial didHideWithAd - Ad: %@", ad]];
+- (void)didHideAd:(CLXAd *)ad {
+    [[DemoAppLogger sharedInstance] logMessage:[NSString stringWithFormat:@"🔚 RewardedInterstitial didHideAd - Ad: %@", ad]];
     self.rewardedInterstitialAd = nil;
     [self loadRewardedInterstitial];
     [self updateStatusUIWithState:AdStateNoAd];
 }
 
-- (void)didClickWithAd:(CLXAd *)ad {
-    [[DemoAppLogger sharedInstance] logMessage:[NSString stringWithFormat:@"👆 RewardedInterstitial didClickWithAd - Ad: %@", ad]];
+- (void)didClickAd:(CLXAd *)ad {
+    [[DemoAppLogger sharedInstance] logMessage:[NSString stringWithFormat:@"👆 RewardedInterstitial didClickAd - Ad: %@", ad]];
 }
 
-- (void)impressionOn:(CLXAd *)ad {
-    [[DemoAppLogger sharedInstance] logMessage:[NSString stringWithFormat:@"👁️ RewardedInterstitial impressionOn - Ad: %@", ad]];
+- (void)didRecordImpressionForAd:(CLXAd *)ad {
+    [[DemoAppLogger sharedInstance] logMessage:[NSString stringWithFormat:@"👁️ RewardedInterstitial didRecordImpressionForAd - Ad: %@", ad]];
 }
 
-- (void)revenuePaid:(CLXAd *)ad {
-    [[DemoAppLogger sharedInstance] logMessage:[NSString stringWithFormat:@"💰 RewardedInterstitial revenuePaid - Ad: %@", ad]];
+- (void)didPayRevenueForAd:(CLXAd *)ad {
+    [[DemoAppLogger sharedInstance] logMessage:[NSString stringWithFormat:@"💰 RewardedInterstitial didPayRevenueForAd - Ad: %@", ad]];
 }
 
 - (void)userRewarded:(CLXAd *)ad {

--- a/demo-app-objc/CloudXObjCRemotePods/Views/Ad/RewardedViewController.m
+++ b/demo-app-objc/CloudXObjCRemotePods/Views/Ad/RewardedViewController.m
@@ -211,15 +211,15 @@
 
 #pragma mark - CLXRewardedDelegate
 
-- (void)didLoadWithAd:(CLXAd *)ad {
-    [[DemoAppLogger sharedInstance] logAdEvent:@"✅ Rewarded didLoadWithAd" ad:ad];
+- (void)didLoadAd:(CLXAd *)ad {
+    [[DemoAppLogger sharedInstance] logAdEvent:@"✅ Rewarded didLoadAd" ad:ad];
     self.isLoading = NO;
     [self updateStatusUIWithState:AdStateReady];
     // Do NOT show the ad here!
 }
 
-- (void)failToLoadWithAd:(CLXAd *)ad error:(NSError *)error {
-    [[DemoAppLogger sharedInstance] logMessage:[NSString stringWithFormat:@"❌ Rewarded failToLoadWithAd - Error: %@", error.localizedDescription]];
+- (void)didFailToLoadAdWithError:(CLXError *)error {
+    [[DemoAppLogger sharedInstance] logMessage:[NSString stringWithFormat:@"❌ Rewarded failed to load - Error: %@", error.localizedDescription]];
     self.isLoading = NO;
     [self updateStatusUIWithState:AdStateNoAd];
     
@@ -231,12 +231,12 @@
     });
 }
 
-- (void)didShowWithAd:(CLXAd *)ad {
-    [[DemoAppLogger sharedInstance] logMessage:[NSString stringWithFormat:@"👀 Rewarded didShowWithAd - Ad: %@", ad]];
+- (void)didDisplayAd:(CLXAd *)ad {
+    [[DemoAppLogger sharedInstance] logMessage:[NSString stringWithFormat:@"👀 Rewarded didDisplayAd - Ad: %@", ad]];
 }
 
-- (void)failToShowWithAd:(CLXAd *)ad error:(NSError *)error {
-    [[DemoAppLogger sharedInstance] logMessage:[NSString stringWithFormat:@"❌ Rewarded failToShowWithAd - Error: %@", error.localizedDescription]];
+- (void)didFailToDisplayAd:(CLXAd *)ad error:(CLXError *)error {
+    [[DemoAppLogger sharedInstance] logMessage:[NSString stringWithFormat:@"❌ Rewarded didFailToDisplayAd - Error: %@", error.localizedDescription]];
     [self updateStatusUIWithState:AdStateNoAd];
     
     dispatch_async(dispatch_get_main_queue(), ^{
@@ -246,24 +246,24 @@
     });
 }
 
-- (void)didHideWithAd:(CLXAd *)ad {
-    [[DemoAppLogger sharedInstance] logMessage:[NSString stringWithFormat:@"🔚 Rewarded didHideWithAd - Ad: %@", ad]];
+- (void)didHideAd:(CLXAd *)ad {
+    [[DemoAppLogger sharedInstance] logMessage:[NSString stringWithFormat:@"🔚 Rewarded didHideAd - Ad: %@", ad]];
     self.rewardedAd = nil;
     // Create new ad instance for next time
     [self createRewardedAd];
     [self updateStatusUIWithState:AdStateNoAd];
 }
 
-- (void)didClickWithAd:(CLXAd *)ad {
-    [[DemoAppLogger sharedInstance] logMessage:[NSString stringWithFormat:@"👆 Rewarded didClickWithAd - Ad: %@", ad]];
+- (void)didClickAd:(CLXAd *)ad {
+    [[DemoAppLogger sharedInstance] logMessage:[NSString stringWithFormat:@"👆 Rewarded didClickAd - Ad: %@", ad]];
 }
 
-- (void)impressionOn:(CLXAd *)ad {
-    [[DemoAppLogger sharedInstance] logMessage:[NSString stringWithFormat:@"👁️ Rewarded impressionOn - Ad: %@", ad]];
+- (void)didRecordImpressionForAd:(CLXAd *)ad {
+    [[DemoAppLogger sharedInstance] logMessage:[NSString stringWithFormat:@"👁️ Rewarded didRecordImpressionForAd - Ad: %@", ad]];
 }
 
-- (void)revenuePaid:(CLXAd *)ad {
-    [[DemoAppLogger sharedInstance] logAdEvent:@"💰 Rewarded revenuePaid" ad:ad];
+- (void)didPayRevenueForAd:(CLXAd *)ad {
+    [[DemoAppLogger sharedInstance] logAdEvent:@"💰 Rewarded didPayRevenueForAd" ad:ad];
 }
 
 - (void)userRewarded:(CLXAd *)ad {

--- a/demo-app-swift/CloudXSwiftRemotePods/Views/Ad/BannerViewController.swift
+++ b/demo-app-swift/CloudXSwiftRemotePods/Views/Ad/BannerViewController.swift
@@ -184,71 +184,71 @@ class BannerViewController: BaseAdViewController {
 }
 
 extension BannerViewController: CLXBannerDelegate {
-    func didLoad(with ad: CLXAd) {
-        DemoAppLogger.sharedInstance.logAdEvent("✅ Banner didLoadWithAd", ad: ad)
+    func didLoad(_ ad: CLXAd) {
+        DemoAppLogger.sharedInstance.logAdEvent("✅ Banner didLoadAd", ad: ad)
         isLoading = false
         updateStatusUI(state: .ready)
     }
     
-    func failToLoad(with ad: CLXAd, error: Error) {
-        DemoAppLogger.sharedInstance.logAdEvent("❌ Banner failToLoadWithAd", ad: ad)
+    func didFailToLoadAd(error: CLXError) {
+        DemoAppLogger.sharedInstance.logMessage("❌ Banner failed to load - Error: \(error.localizedDescription)")
         isLoading = false
         updateStatusUI(state: .noAd)
         bannerAd = nil
         
         DispatchQueue.main.async { [weak self] in
-            let errorMessage = (error as NSError).detailedDemoDescription
+            let errorMessage = error.detailedDemoDescription
             self?.showAlert(title: "Banner Ad Load Failed", message: errorMessage)
         }
     }
     
-    func didShow(with ad: CLXAd) {
-        DemoAppLogger.sharedInstance.logAdEvent("👀 Banner didShowWithAd", ad: ad)
+    func didDisplay(_ ad: CLXAd) {
+        DemoAppLogger.sharedInstance.logAdEvent("👀 Banner didDisplayAd", ad: ad)
     }
     
-    func failToShow(with ad: CLXAd, error: Error) {
-        DemoAppLogger.sharedInstance.logAdEvent("❌ Banner failToShowWithAd", ad: ad)
+    func didFailToDisplay(_ ad: CLXAd, error: CLXError) {
+        DemoAppLogger.sharedInstance.logAdEvent("❌ Banner didFailToDisplayAd", ad: ad)
         bannerAd = nil
         
         DispatchQueue.main.async { [weak self] in
-            let errorMessage = (error as NSError).detailedDemoDescription
-            self?.showAlert(title: "Banner Ad Show Failed", message: errorMessage)
+            let errorMessage = error.detailedDemoDescription
+            self?.showAlert(title: "Banner Ad Display Failed", message: errorMessage)
         }
     }
     
-    func didHide(with ad: CLXAd) {
-        DemoAppLogger.sharedInstance.logAdEvent("🔚 Banner didHideWithAd", ad: ad)
+    func didHide(_ ad: CLXAd) {
+        DemoAppLogger.sharedInstance.logAdEvent("🔚 Banner didHideAd", ad: ad)
         bannerAd = nil
     }
     
-    func didClick(with ad: CLXAd) {
-        DemoAppLogger.sharedInstance.logAdEvent("👆 Banner didClickWithAd", ad: ad)
+    func didClick(_ ad: CLXAd) {
+        DemoAppLogger.sharedInstance.logAdEvent("👆 Banner didClickAd", ad: ad)
     }
     
-    func impression(on ad: CLXAd) {
-        DemoAppLogger.sharedInstance.logAdEvent("👁️ Banner impressionOn", ad: ad)
+    func didRecordImpression(for ad: CLXAd) {
+        DemoAppLogger.sharedInstance.logAdEvent("👁️ Banner didRecordImpression", ad: ad)
     }
     
-    func revenuePaid(_ ad: CLXAd) {
-        DemoAppLogger.sharedInstance.logAdEvent("💰 Banner revenuePaid", ad: ad)
+    func didPayRevenue(for ad: CLXAd) {
+        DemoAppLogger.sharedInstance.logAdEvent("💰 Banner didPayRevenue", ad: ad)
     }
     
-    // NEW MAX SDK Compatibility Delegate Methods
+    // Banner-specific delegate methods
     func didExpand(_ ad: CLXAd) {
         DemoAppLogger.sharedInstance.logAdEvent("🔍 Banner didExpandAd", ad: ad)
         
         DispatchQueue.main.async { [weak self] in
             self?.showAlert(title: "Banner Expanded!", 
-                           message: "Banner ad expanded to full screen. This is a new MAX SDK compatibility feature.")
+                           message: "Banner ad expanded to full screen.")
         }
     }
     
     func didCollapse(_ ad: CLXAd) {
-        DemoAppLogger.sharedInstance.logAdEvent("🔍 Banner didCollapseAd", ad: ad)
+        DemoAppLogger.sharedInstance.logAdEvent("🔽 Banner didCollapseAd", ad: ad)
         
         DispatchQueue.main.async { [weak self] in
             self?.showAlert(title: "Banner Collapsed!", 
-                           message: "Banner ad collapsed from full screen. This is a new MAX SDK compatibility feature.")
+                           message: "Banner ad collapsed back to normal size.")
         }
     }
 }

--- a/demo-app-swift/CloudXSwiftRemotePods/Views/Ad/InterstitialViewController.swift
+++ b/demo-app-swift/CloudXSwiftRemotePods/Views/Ad/InterstitialViewController.swift
@@ -185,15 +185,15 @@ class InterstitialViewController: BaseAdViewController {
 }
 
 extension InterstitialViewController: CLXInterstitialDelegate {
-    func didLoad(with ad: CLXAd) {
-        DemoAppLogger.sharedInstance.logAdEvent("✅ Interstitial didLoadWithAd", ad: ad)
+    func didLoad(_ ad: CLXAd) {
+        DemoAppLogger.sharedInstance.logAdEvent("✅ Interstitial didLoadAd", ad: ad)
         isLoading = false
         updateStatusUI(state: AdState.ready)
         // Don't auto-show - wait for user to press Show Interstitial button
     }
     
-    func failToLoad(with ad: CLXAd, error: Error) {
-        DemoAppLogger.sharedInstance.logAdEvent("❌ Interstitial failToLoadWithAd", ad: ad)
+    func didFailToLoadAd(error: CLXError) {
+        DemoAppLogger.sharedInstance.logMessage("❌ Interstitial failed to load - Error: \(error.localizedDescription)")
         isLoading = false
         updateStatusUI(state: AdState.noAd)
         
@@ -204,12 +204,12 @@ extension InterstitialViewController: CLXInterstitialDelegate {
         }
     }
     
-    func didShow(with ad: CLXAd) {
-        DemoAppLogger.sharedInstance.logAdEvent("👀 Interstitial didShowWithAd", ad: ad)
+    func didDisplay(_ ad: CLXAd) {
+        DemoAppLogger.sharedInstance.logAdEvent("👀 Interstitial didDisplayAd", ad: ad)
     }
     
-    func failToShow(with ad: CLXAd, error: Error) {
-        DemoAppLogger.sharedInstance.logAdEvent("❌ Interstitial failToShowWithAd", ad: ad)
+    func didFailToDisplay(_ ad: CLXAd, error: CLXError) {
+        DemoAppLogger.sharedInstance.logAdEvent("❌ Interstitial didFailToDisplayAd", ad: ad)
         updateStatusUI(state: AdState.noAd)
         
         DispatchQueue.main.async { [weak self] in
@@ -219,8 +219,8 @@ extension InterstitialViewController: CLXInterstitialDelegate {
         }
     }
     
-    func didHide(with ad: CLXAd) {
-        DemoAppLogger.sharedInstance.logAdEvent("🔚 Interstitial didHideWithAd", ad: ad)
+    func didHide(_ ad: CLXAd) {
+        DemoAppLogger.sharedInstance.logAdEvent("🔚 Interstitial didHideAd", ad: ad)
         
         showAdWhenLoaded = false
         interstitialAd = nil
@@ -229,15 +229,15 @@ extension InterstitialViewController: CLXInterstitialDelegate {
         updateStatusUI(state: AdState.noAd)
     }
     
-    func didClick(with ad: CLXAd) {
-        DemoAppLogger.sharedInstance.logAdEvent("👆 Interstitial didClickWithAd", ad: ad)
+    func didClick(_ ad: CLXAd) {
+        DemoAppLogger.sharedInstance.logAdEvent("👆 Interstitial didClickAd", ad: ad)
     }
     
-    func impression(on ad: CLXAd) {
-        DemoAppLogger.sharedInstance.logAdEvent("👁️ Interstitial impressionOn", ad: ad)
+    func didRecordImpression(for ad: CLXAd) {
+        DemoAppLogger.sharedInstance.logAdEvent("👁️ Interstitial didRecordImpression", ad: ad)
     }
     
-    func revenuePaid(_ ad: CLXAd) {
-        DemoAppLogger.sharedInstance.logAdEvent("💰 Interstitial revenuePaid", ad: ad)
+    func didPayRevenue(for ad: CLXAd) {
+        DemoAppLogger.sharedInstance.logAdEvent("💰 Interstitial didPayRevenue", ad: ad)
     }
 } 

--- a/demo-app-swift/CloudXSwiftRemotePods/Views/Ad/MRECViewController.swift
+++ b/demo-app-swift/CloudXSwiftRemotePods/Views/Ad/MRECViewController.swift
@@ -195,16 +195,16 @@ class MRECViewController: BaseAdViewController, CLXBannerDelegate {
     
     // MARK: - CLXBannerDelegate
     
-    func didLoad(with ad: CLXAd) {
-        DemoAppLogger.sharedInstance.logAdEvent("✅ MREC didLoadWithAd", ad: ad)
+    func didLoad(_ ad: CLXAd) {
+        DemoAppLogger.sharedInstance.logAdEvent("✅ MREC didLoadAd", ad: ad)
         isLoading = false
         updateStatusUI(state: .ready)
         
         // Don't auto-show - user must press Show MREC button
     }
     
-    func failToLoad(with ad: CLXAd, error: Error) {
-        DemoAppLogger.sharedInstance.logAdEvent("❌ MREC failToLoadWithAd", ad: ad)
+    func didFailToLoadAd(error: CLXError) {
+        DemoAppLogger.sharedInstance.logMessage("❌ MREC failed to load - Error: \(error.localizedDescription)")
         isLoading = false
         
         DispatchQueue.main.async { [weak self] in
@@ -213,12 +213,12 @@ class MRECViewController: BaseAdViewController, CLXBannerDelegate {
         }
     }
     
-    func didShow(with ad: CLXAd) {
-        DemoAppLogger.sharedInstance.logAdEvent("👀 MREC didShowWithAd", ad: ad)
+    func didDisplay(_ ad: CLXAd) {
+        DemoAppLogger.sharedInstance.logAdEvent("👀 MREC didDisplayAd", ad: ad)
     }
     
-    func failToShow(with ad: CLXAd, error: Error) {
-        DemoAppLogger.sharedInstance.logAdEvent("❌ MREC failToShowWithAd", ad: ad)
+    func didFailToDisplay(_ ad: CLXAd, error: CLXError) {
+        DemoAppLogger.sharedInstance.logAdEvent("❌ MREC didFailToDisplayAd", ad: ad)
         
         DispatchQueue.main.async { [weak self] in
             let errorMessage = error.localizedDescription
@@ -226,21 +226,21 @@ class MRECViewController: BaseAdViewController, CLXBannerDelegate {
         }
     }
     
-    func didHide(with ad: CLXAd) {
-        DemoAppLogger.sharedInstance.logAdEvent("🔚 MREC didHideWithAd", ad: ad)
+    func didHide(_ ad: CLXAd) {
+        DemoAppLogger.sharedInstance.logAdEvent("🔚 MREC didHideAd", ad: ad)
         mrecAd = nil
     }
     
-    func didClick(with ad: CLXAd) {
-        DemoAppLogger.sharedInstance.logAdEvent("👆 MREC didClickWithAd", ad: ad)
+    func didClick(_ ad: CLXAd) {
+        DemoAppLogger.sharedInstance.logAdEvent("👆 MREC didClickAd", ad: ad)
     }
     
-    func impression(on ad: CLXAd) {
-        DemoAppLogger.sharedInstance.logAdEvent("👁️ MREC impressionOn", ad: ad)
+    func didRecordImpression(for ad: CLXAd) {
+        DemoAppLogger.sharedInstance.logAdEvent("👁️ MREC didRecordImpression", ad: ad)
     }
     
-    func revenuePaid(_ ad: CLXAd) {
-        DemoAppLogger.sharedInstance.logAdEvent("💰 MREC revenuePaid", ad: ad)
+    func didPayRevenue(for ad: CLXAd) {
+        DemoAppLogger.sharedInstance.logAdEvent("💰 MREC didPayRevenue", ad: ad)
     }
     
     // Banner-specific delegate methods (MREC is a banner type)
@@ -254,11 +254,11 @@ class MRECViewController: BaseAdViewController, CLXBannerDelegate {
     }
     
     func didCollapse(_ ad: CLXAd) {
-        DemoAppLogger.sharedInstance.logAdEvent("🔍 MREC didCollapseAd", ad: ad)
+        DemoAppLogger.sharedInstance.logAdEvent("🔽 MREC didCollapseAd", ad: ad)
         
         DispatchQueue.main.async { [weak self] in
             self?.showAlert(title: "MREC Collapsed!", 
-                           message: "MREC ad collapsed from full screen.")
+                           message: "MREC ad collapsed back to normal size.")
         }
     }
 }

--- a/demo-app-swift/CloudXSwiftRemotePods/Views/Ad/NativeBannerViewController.swift
+++ b/demo-app-swift/CloudXSwiftRemotePods/Views/Ad/NativeBannerViewController.swift
@@ -165,15 +165,15 @@ class NativeBannerViewController: BaseAdViewController, CLXNativeDelegate {
     
     // MARK: - CLXNativeDelegate
     
-    func didLoad(with ad: CLXAd) {
-        DemoAppLogger.sharedInstance.logAdEvent("✅ NativeBanner didLoadWithAd", ad: ad)
+    func didLoad(_ ad: CLXAd) {
+        DemoAppLogger.sharedInstance.logAdEvent("✅ NativeBanner didLoadAd", ad: ad)
         DispatchQueue.main.async { [weak self] in
             self?.updateStatusUI(state: .ready)
         }
     }
     
-    func failToLoad(with ad: CLXAd, error: Error) {
-        DemoAppLogger.sharedInstance.logMessage("❌ NativeBanner failToLoadWithAd - Error: \(error.localizedDescription)")
+    func didFailToLoadAd(error: CLXError) {
+        DemoAppLogger.sharedInstance.logMessage("❌ NativeBanner failed to load - Error: \(error.localizedDescription)")
         
         DispatchQueue.main.async { [weak self] in
             self?.nativeBannerAd = nil
@@ -182,12 +182,12 @@ class NativeBannerViewController: BaseAdViewController, CLXNativeDelegate {
         }
     }
     
-    func didShow(with ad: CLXAd) {
-        DemoAppLogger.sharedInstance.logAdEvent("👀 NativeBanner didShowWithAd", ad: ad)
+    func didDisplay(_ ad: CLXAd) {
+        DemoAppLogger.sharedInstance.logAdEvent("👀 NativeBanner didDisplayAd", ad: ad)
     }
     
-    func failToShow(with ad: CLXAd, error: Error) {
-        DemoAppLogger.sharedInstance.logMessage("❌ NativeBanner failToShowWithAd - Error: \(error.localizedDescription)")
+    func didFailToDisplay(_ ad: CLXAd, error: CLXError) {
+        DemoAppLogger.sharedInstance.logMessage("❌ NativeBanner didFailToDisplayAd - Error: \(error.localizedDescription)")
         
         DispatchQueue.main.async { [weak self] in
             self?.nativeBannerAd = nil
@@ -196,20 +196,20 @@ class NativeBannerViewController: BaseAdViewController, CLXNativeDelegate {
         }
     }
     
-    func didHide(with ad: CLXAd) {
-        DemoAppLogger.sharedInstance.logMessage("🔚 NativeBanner didHideWithAd - Ad: \(ad)")
+    func didHide(_ ad: CLXAd) {
+        DemoAppLogger.sharedInstance.logMessage("🔚 NativeBanner didHideAd - Ad: \(ad)")
         nativeBannerAd = nil
     }
     
-    func didClick(with ad: CLXAd) {
-        DemoAppLogger.sharedInstance.logMessage("👆 NativeBanner didClickWithAd - Ad: \(ad)")
+    func didClick(_ ad: CLXAd) {
+        DemoAppLogger.sharedInstance.logMessage("👆 NativeBanner didClickAd - Ad: \(ad)")
     }
     
-    func impression(on ad: CLXAd) {
-        DemoAppLogger.sharedInstance.logAdEvent("👁️ NativeBanner impressionOn", ad: ad)
+    func didRecordImpression(for ad: CLXAd) {
+        DemoAppLogger.sharedInstance.logAdEvent("👁️ NativeBanner didRecordImpression", ad: ad)
     }
     
-    func revenuePaid(_ ad: CLXAd) {
-        DemoAppLogger.sharedInstance.logAdEvent("💰 NativeBanner revenuePaid", ad: ad)
+    func didPayRevenue(for ad: CLXAd) {
+        DemoAppLogger.sharedInstance.logAdEvent("💰 NativeBanner didPayRevenue", ad: ad)
     }
 }

--- a/demo-app-swift/CloudXSwiftRemotePods/Views/Ad/NativeViewController.swift
+++ b/demo-app-swift/CloudXSwiftRemotePods/Views/Ad/NativeViewController.swift
@@ -154,8 +154,8 @@ class NativeViewController: BaseAdViewController, CLXNativeDelegate {
     
     // MARK: - CLXNativeDelegate
     
-    func didLoad(with ad: CLXAd) {
-        DemoAppLogger.sharedInstance.logAdEvent("✅ Native didLoadWithAd", ad: ad)
+    func didLoad(_ ad: CLXAd) {
+        DemoAppLogger.sharedInstance.logAdEvent("✅ Native didLoadAd", ad: ad)
         DispatchQueue.main.async { [weak self] in
             self?.isLoading = false
             self?.updateStatusUI(state: .ready)
@@ -164,8 +164,8 @@ class NativeViewController: BaseAdViewController, CLXNativeDelegate {
         // Don't auto-show - user must press Show Native button
     }
     
-    func failToLoad(with ad: CLXAd, error: Error) {
-        DemoAppLogger.sharedInstance.logAdEvent("❌ Native failToLoadWithAd", ad: ad)
+    func didFailToLoadAd(error: CLXError) {
+        DemoAppLogger.sharedInstance.logMessage("❌ Native failed to load - Error: \(error.localizedDescription)")
         
         DispatchQueue.main.async { [weak self] in
             self?.nativeAd = nil
@@ -174,12 +174,12 @@ class NativeViewController: BaseAdViewController, CLXNativeDelegate {
         }
     }
     
-    func didShow(with ad: CLXAd) {
-        DemoAppLogger.sharedInstance.logAdEvent("👀 Native didShowWithAd", ad: ad)
+    func didDisplay(_ ad: CLXAd) {
+        DemoAppLogger.sharedInstance.logAdEvent("👀 Native didDisplayAd", ad: ad)
     }
     
-    func failToShow(with ad: CLXAd, error: Error) {
-        DemoAppLogger.sharedInstance.logAdEvent("❌ Native failToShowWithAd", ad: ad)
+    func didFailToDisplay(_ ad: CLXAd, error: CLXError) {
+        DemoAppLogger.sharedInstance.logAdEvent("❌ Native didFailToDisplayAd", ad: ad)
         
         DispatchQueue.main.async { [weak self] in
             self?.nativeAd = nil
@@ -188,20 +188,20 @@ class NativeViewController: BaseAdViewController, CLXNativeDelegate {
         }
     }
     
-    func didHide(with ad: CLXAd) {
-        DemoAppLogger.sharedInstance.logAdEvent("🔚 Native didHideWithAd", ad: ad)
+    func didHide(_ ad: CLXAd) {
+        DemoAppLogger.sharedInstance.logAdEvent("🔚 Native didHideAd", ad: ad)
         nativeAd = nil
     }
     
-    func didClick(with ad: CLXAd) {
-        DemoAppLogger.sharedInstance.logAdEvent("👆 Native didClickWithAd", ad: ad)
+    func didClick(_ ad: CLXAd) {
+        DemoAppLogger.sharedInstance.logAdEvent("👆 Native didClickAd", ad: ad)
     }
     
-    func impression(on ad: CLXAd) {
-        DemoAppLogger.sharedInstance.logAdEvent("👁️ Native impressionOn", ad: ad)
+    func didRecordImpression(for ad: CLXAd) {
+        DemoAppLogger.sharedInstance.logAdEvent("👁️ Native didRecordImpression", ad: ad)
     }
     
-    func revenuePaid(_ ad: CLXAd) {
-        DemoAppLogger.sharedInstance.logAdEvent("💰 Native revenuePaid", ad: ad)
+    func didPayRevenue(for ad: CLXAd) {
+        DemoAppLogger.sharedInstance.logAdEvent("💰 Native didPayRevenue", ad: ad)
     }
 }

--- a/demo-app-swift/CloudXSwiftRemotePods/Views/Ad/RewardedInterstitialViewController.swift
+++ b/demo-app-swift/CloudXSwiftRemotePods/Views/Ad/RewardedInterstitialViewController.swift
@@ -133,56 +133,56 @@ class RewardedInterstitialViewController: BaseAdViewController, CLXRewardedDeleg
     
     // MARK: - CLXRewardedDelegate
     
-    func didLoad(with ad: CLXAd) {
-        DemoAppLogger.sharedInstance.logAdEvent("✅ RewardedInterstitial didLoadWithAd", ad: ad)
+    func didLoad(_ ad: CLXAd) {
+        DemoAppLogger.sharedInstance.logAdEvent("✅ RewardedInterstitial didLoadAd", ad: ad)
         isLoading = false
         updateStatusUI(state: .ready)
     }
     
-    func failToLoad(with ad: CLXAd, error: Error) {
-        DemoAppLogger.sharedInstance.logAdEvent("❌ RewardedInterstitial failToLoadWithAd", ad: ad)
+    func didFailToLoadAd(error: CLXError) {
+        DemoAppLogger.sharedInstance.logMessage("❌ RewardedInterstitial failed to load - Error: \(error.localizedDescription)")
         isLoading = false
         updateStatusUI(state: .noAd)
         
         DispatchQueue.main.async { [weak self] in
-            let errorMessage = (error as NSError).detailedDemoDescription
+            let errorMessage = error.detailedDemoDescription
             self?.showAlert(title: "Rewarded Interstitial Load Failed", message: errorMessage)
             self?.rewardedInterstitialAd = nil
         }
     }
     
-    func didShow(with ad: CLXAd) {
-        DemoAppLogger.sharedInstance.logAdEvent("👀 RewardedInterstitial didShowWithAd", ad: ad)
+    func didDisplay(_ ad: CLXAd) {
+        DemoAppLogger.sharedInstance.logAdEvent("👀 RewardedInterstitial didDisplayAd", ad: ad)
     }
     
-    func failToShow(with ad: CLXAd, error: Error) {
-        DemoAppLogger.sharedInstance.logAdEvent("❌ RewardedInterstitial failToShowWithAd", ad: ad)
+    func didFailToDisplay(_ ad: CLXAd, error: CLXError) {
+        DemoAppLogger.sharedInstance.logAdEvent("❌ RewardedInterstitial didFailToDisplayAd", ad: ad)
         updateStatusUI(state: .noAd)
         
         DispatchQueue.main.async { [weak self] in
             self?.rewardedInterstitialAd = nil
-            let errorMessage = (error as NSError).detailedDemoDescription
+            let errorMessage = error.detailedDemoDescription
             self?.showAlert(title: "Rewarded Interstitial Show Failed", message: errorMessage)
         }
     }
     
-    func didHide(with ad: CLXAd) {
-        DemoAppLogger.sharedInstance.logAdEvent("🔚 RewardedInterstitial didHideWithAd", ad: ad)
+    func didHide(_ ad: CLXAd) {
+        DemoAppLogger.sharedInstance.logAdEvent("🔚 RewardedInterstitial didHideAd", ad: ad)
         rewardedInterstitialAd = nil
         loadRewardedInterstitial()
         updateStatusUI(state: .noAd)
     }
     
-    func didClick(with ad: CLXAd) {
-        DemoAppLogger.sharedInstance.logAdEvent("👆 RewardedInterstitial didClickWithAd", ad: ad)
+    func didClick(_ ad: CLXAd) {
+        DemoAppLogger.sharedInstance.logAdEvent("👆 RewardedInterstitial didClickAd", ad: ad)
     }
     
-    func impression(on ad: CLXAd) {
-        DemoAppLogger.sharedInstance.logAdEvent("👁️ RewardedInterstitial impressionOn", ad: ad)
+    func didRecordImpression(for ad: CLXAd) {
+        DemoAppLogger.sharedInstance.logAdEvent("👁️ RewardedInterstitial didRecordImpression", ad: ad)
     }
     
-    func revenuePaid(_ ad: CLXAd) {
-        DemoAppLogger.sharedInstance.logAdEvent("💰 RewardedInterstitial revenuePaid", ad: ad)
+    func didPayRevenue(for ad: CLXAd) {
+        DemoAppLogger.sharedInstance.logAdEvent("💰 RewardedInterstitial didPayRevenue", ad: ad)
     }
     
     func userRewarded(_ ad: CLXAd) {

--- a/demo-app-swift/CloudXSwiftRemotePods/Views/Ad/RewardedViewController.swift
+++ b/demo-app-swift/CloudXSwiftRemotePods/Views/Ad/RewardedViewController.swift
@@ -159,55 +159,55 @@ class RewardedViewController: BaseAdViewController, CLXRewardedDelegate {
     
     // MARK: - CLXRewardedDelegate
     
-    func didLoad(with ad: CLXAd) {
-        DemoAppLogger.sharedInstance.logAdEvent("✅ Rewarded didLoadWithAd", ad: ad)
+    func didLoad(_ ad: CLXAd) {
+        DemoAppLogger.sharedInstance.logAdEvent("✅ Rewarded didLoadAd", ad: ad)
         isLoading = false
         updateStatusUI(state: .ready)
     }
     
-    func failToLoad(with ad: CLXAd, error: Error) {
-        DemoAppLogger.sharedInstance.logAdEvent("❌ Rewarded failToLoadWithAd", ad: ad)
+    func didFailToLoadAd(error: CLXError) {
+        DemoAppLogger.sharedInstance.logMessage("❌ Rewarded failed to load - Error: \(error.localizedDescription)")
         isLoading = false
         updateStatusUI(state: .noAd)
         
         DispatchQueue.main.async { [weak self] in
-            let errorMessage = (error as NSError).detailedDemoDescription
+            let errorMessage = error.detailedDemoDescription
             self?.showAlert(title: "Rewarded Ad Load Failed", message: errorMessage)
             self?.rewardedAd = nil
         }
     }
     
-    func didShow(with ad: CLXAd) {
-        DemoAppLogger.sharedInstance.logAdEvent("👀 Rewarded didShowWithAd", ad: ad)
+    func didDisplay(_ ad: CLXAd) {
+        DemoAppLogger.sharedInstance.logAdEvent("👀 Rewarded didDisplayAd", ad: ad)
     }
     
-    func failToShow(with ad: CLXAd, error: Error) {
-        DemoAppLogger.sharedInstance.logAdEvent("❌ Rewarded failToShowWithAd", ad: ad)
+    func didFailToDisplay(_ ad: CLXAd, error: CLXError) {
+        DemoAppLogger.sharedInstance.logAdEvent("❌ Rewarded didFailToDisplayAd", ad: ad)
         updateStatusUI(state: .noAd)
         
         DispatchQueue.main.async { [weak self] in
             self?.rewardedAd = nil
-            let errorMessage = (error as NSError).detailedDemoDescription
+            let errorMessage = error.detailedDemoDescription
             self?.showAlert(title: "Rewarded Ad Show Failed", message: errorMessage)
         }
     }
     
-    func didHide(with ad: CLXAd) {
-        DemoAppLogger.sharedInstance.logAdEvent("🔚 Rewarded didHideWithAd", ad: ad)
+    func didHide(_ ad: CLXAd) {
+        DemoAppLogger.sharedInstance.logAdEvent("🔚 Rewarded didHideAd", ad: ad)
         rewardedAd = nil
         updateStatusUI(state: .noAd)
     }
     
-    func didClick(with ad: CLXAd) {
-        DemoAppLogger.sharedInstance.logAdEvent("👆 Rewarded didClickWithAd", ad: ad)
+    func didClick(_ ad: CLXAd) {
+        DemoAppLogger.sharedInstance.logAdEvent("👆 Rewarded didClickAd", ad: ad)
     }
     
-    func impression(on ad: CLXAd) {
-        DemoAppLogger.sharedInstance.logAdEvent("👁️ Rewarded impressionOn", ad: ad)
+    func didRecordImpression(for ad: CLXAd) {
+        DemoAppLogger.sharedInstance.logAdEvent("👁️ Rewarded didRecordImpression", ad: ad)
     }
     
-    func revenuePaid(_ ad: CLXAd) {
-        DemoAppLogger.sharedInstance.logAdEvent("💰 Rewarded revenuePaid", ad: ad)
+    func didPayRevenue(for ad: CLXAd) {
+        DemoAppLogger.sharedInstance.logAdEvent("💰 Rewarded didPayRevenue", ad: ad)
     }
     
     func userRewarded(_ ad: CLXAd) {


### PR DESCRIPTION
## Summary

Updates the demo apps to use the new `CLXAdDelegate` API that passes `CLXError` instead of `NSError` in error callbacks.

## Changes (14 files)

### ObjC Demo App (7 files)
- BannerViewController.m
- InterstitialViewController.m  
- MRECViewController.m
- NativeBannerViewController.m
- NativeViewController.m
- RewardedInterstitialViewController.m
- RewardedViewController.m

### Swift Demo App (7 files)
- BannerViewController.swift
- InterstitialViewController.swift
- MRECViewController.swift
- NativeBannerViewController.swift
- NativeViewController.swift
- RewardedInterstitialViewController.swift
- RewardedViewController.swift

## Delegate API Changes

| Old Method | New Method |
|------------|------------|
| `didLoadWithAd:` | `didLoadAd:` |
| `failToLoadWithAd:error:` | `didFailToLoadAdWithError:` (no ad param, uses CLXError) |
| `didShowWithAd:` | `didDisplayAd:` |
| `failToShowWithAd:error:` | `didFailToDisplayAd:error:` |
| `didHideWithAd:` | `didHideAd:` |
| `didClickWithAd:` | `didClickAd:` |
| `impressionOn:` | `didRecordImpressionForAd:` |
| `revenuePaid:` | `didPayRevenueForAd:` |

## Note
⚠️ These demo apps require the updated CloudXCore.xcframework with CLXError support to compile. The framework must be built from cloudx-ios-private after merging the CLXError changes.

## Related PRs
- cloudx-ios-private #200: Core SDK CLXError implementation
- cloudx-react-native #10: React Native bridge updates