### PR TITLE
feat: add testMode parameter to demo app SDK initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ pod install
 import CloudXCore
 
 // 1. Initialize (in AppDelegate)
-// Production: testMode defaults to false
-CloudXCore.shared.initializeSDK(appKey: "YOUR_APP_KEY") { success, error in
+// Production: Use testMode:false for real ads
+CloudXCore.shared.initializeSDK(appKey: "YOUR_APP_KEY", testMode: false) { success, error in
     print(success ? "Ready!" : "Error: \(error!)")
 }
 

--- a/README.md
+++ b/README.md
@@ -28,15 +28,10 @@ pod install
 import CloudXCore
 
 // 1. Initialize (in AppDelegate)
-// Production: Use testMode:false for real ads
+// testMode: false = production, true = test ads
 CloudXCore.shared.initializeSDK(appKey: "YOUR_APP_KEY", testMode: false) { success, error in
     print(success ? "Ready!" : "Error: \(error!)")
 }
-
-// Development/QA: Enable test mode for testing
-// CloudXCore.shared.initializeSDK(appKey: "YOUR_APP_KEY", testMode: true) { success, error in
-//     print(success ? "Test mode enabled" : "Error: \(error!)")
-// }
 
 // 2. Create banner ad (in ViewController)
 let banner = CloudXCore.shared.createBanner(

--- a/README.md
+++ b/README.md
@@ -28,9 +28,15 @@ pod install
 import CloudXCore
 
 // 1. Initialize (in AppDelegate)
-CloudXCore.shared.initializeSDK(withAppKey: "YOUR_APP_KEY") { error in
-    print(error == nil ? "Ready!" : "Error: \(error!)")
+// Production: testMode defaults to false
+CloudXCore.shared.initializeSDK(appKey: "YOUR_APP_KEY") { success, error in
+    print(success ? "Ready!" : "Error: \(error!)")
 }
+
+// Development/QA: Enable test mode for testing
+// CloudXCore.shared.initializeSDK(appKey: "YOUR_APP_KEY", testMode: true) { success, error in
+//     print(success ? "Test mode enabled" : "Error: \(error!)")
+// }
 
 // 2. Create banner ad (in ViewController)
 let banner = CloudXCore.shared.createBanner(

--- a/demo-app-objc/CloudXObjCRemotePods/Views/Ad/BaseAdViewController.m
+++ b/demo-app-objc/CloudXObjCRemotePods/Views/Ad/BaseAdViewController.m
@@ -78,7 +78,8 @@
         }
         
         [self updateStatusUIWithState:AdStateLoading];
-        [[CloudXCore shared] initializeSDKWithAppKey:appKey completion:^(BOOL success, NSError * _Nullable error) {
+        // Production demo app - use testMode:NO for real ads
+        [[CloudXCore shared] initializeSDKWithAppKey:appKey testMode:NO completion:^(BOOL success, CLXError * _Nullable error) {
             dispatch_async(dispatch_get_main_queue(), ^{
                 if (success) {
                     [[NSNotificationCenter defaultCenter] postNotificationName:@"cloudXSDKInitialized" object:nil];

--- a/demo-app-objc/CloudXObjCRemotePods/Views/Ad/InitInternalViewController.m
+++ b/demo-app-objc/CloudXObjCRemotePods/Views/Ad/InitInternalViewController.m
@@ -73,8 +73,10 @@
     }
     
     // Use standard CloudXCore initialization
+    // Production demo app - use testMode:NO for real ads
     [[CloudXCore shared] initializeSDKWithAppKey:config.appKey 
-                                completion:^(BOOL success, NSError * _Nullable error) {
+                                testMode:NO
+                                completion:^(BOOL success, CLXError * _Nullable error) {
         dispatch_async(dispatch_get_main_queue(), ^{
             if (success) {
                 [[DemoAppLogger sharedInstance] logMessage:@"✅ SDK initialized successfully"];

--- a/demo-app-swift/CloudXSwiftRemotePods/Views/Ad/BaseAdViewController.swift
+++ b/demo-app-swift/CloudXSwiftRemotePods/Views/Ad/BaseAdViewController.swift
@@ -90,7 +90,8 @@ class BaseAdViewController: UIViewController, AdStateManaging {
         }
 
         return await withCheckedContinuation { continuation in
-            cloudX.initializeSDK(appKey: appKey) { success, error in
+            // Production demo app - use testMode: false for real ads
+            cloudX.initializeSDK(appKey: appKey, testMode: false) { success, error in
                 if success {
                     print("✅ SDK Initialized: \(success)")
                     NotificationCenter.default.post(name: .sdkInitialized, object: nil)

--- a/demo-app-swift/CloudXSwiftRemotePods/Views/Ad/InitInternalViewController.swift
+++ b/demo-app-swift/CloudXSwiftRemotePods/Views/Ad/InitInternalViewController.swift
@@ -70,7 +70,8 @@ class InitInternalViewController: BaseAdViewController {
         }
         
         // Use standard CloudXCore initialization
-        CloudXCore.shared.initializeSDK(appKey: config.appKey) { [weak self] success, error in
+        // Production demo app - use testMode: false for real ads
+        CloudXCore.shared.initializeSDK(appKey: config.appKey, testMode: false) { [weak self] success, error in
             guard let self = self else { return }
             
             DispatchQueue.main.async {

--- a/demo-app-swift/CloudXSwiftRemotePods/Views/Ad/InitViewController.swift
+++ b/demo-app-swift/CloudXSwiftRemotePods/Views/Ad/InitViewController.swift
@@ -72,7 +72,8 @@ class InitViewController: BaseAdViewController {
             CloudXCore.shared.setHashedUserID(config.hashedUserId)
         }
         
-        CloudXCore.shared.initializeSDK(appKey: config.appKey) { [weak self] success, error in
+        // Production demo app - use testMode: false for real ads
+        CloudXCore.shared.initializeSDK(appKey: config.appKey, testMode: false) { [weak self] success, error in
             guard let self = self else { return }
             
             if success {


### PR DESCRIPTION
### Changes
- Update Swift demo app to use `initializeSDK(appKey:testMode:completion:)`
- Update Objective-C demo app to use `initializeSDKWithAppKey:testMode:completion:`
- Set `testMode:false/NO` for production demo apps (real ads)
- Update delegate signatures from NSError to CLXError

### Related
- Prepares public demo apps for production release
- Aligns with private SDK testMode API changes
- Maintains CLXError consistency across SDK