### PR TITLE
fix: Correct vendored_frameworks paths in podspecs

### DIFF
--- a/adapter-inmobi/CloudXInMobiAdapter.podspec
+++ b/adapter-inmobi/CloudXInMobiAdapter.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.source           = { :git => 'https://github.com/cloudx-io/cloudx-ios.git', :tag => "v#{s.version}-inmobi" }
   
   s.ios.deployment_target = '15.0'
-  s.vendored_frameworks = 'CloudXInMobiAdapter.xcframework'
+  s.vendored_frameworks = 'adapter-inmobi/CloudXInMobiAdapter.xcframework'
   
   # Dependencies
   s.dependency 'CloudXCore', '1.2.1'

--- a/adapter-meta/CloudXMetaAdapter.podspec
+++ b/adapter-meta/CloudXMetaAdapter.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.source           = { :git => 'https://github.com/cloudx-io/cloudx-ios.git', :tag => "v#{s.version}-meta" }
   
   s.ios.deployment_target = '15.0'
-  s.vendored_frameworks = 'CloudXMetaAdapter.xcframework'
+  s.vendored_frameworks = 'adapter-meta/CloudXMetaAdapter.xcframework'
   
   # Dependencies
   s.dependency 'CloudXCore', '1.2.1'

--- a/adapter-vungle/CloudXVungleAdapter.podspec
+++ b/adapter-vungle/CloudXVungleAdapter.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.source           = { :git => 'https://github.com/cloudx-io/cloudx-ios.git', :tag => "v#{s.version}-vungle" }
   
   s.ios.deployment_target = '15.0'
-  s.vendored_frameworks = 'CloudXVungleAdapter.xcframework'
+  s.vendored_frameworks = 'adapter-vungle/CloudXVungleAdapter.xcframework'
   
   # Dependencies
   s.dependency 'CloudXCore', '1.2.1'

--- a/core/CloudXCore.podspec
+++ b/core/CloudXCore.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.source           = { :git => 'https://github.com/cloudx-io/cloudx-ios.git', :tag => "v#{s.version}-core" }
   
   s.ios.deployment_target = '15.0'
-  s.vendored_frameworks = 'CloudXCore.xcframework'
+  s.vendored_frameworks = 'core/CloudXCore.xcframework'
   
   s.frameworks = ['Foundation', 'SafariServices', 'UIKit', 'CoreLocation', 'WebKit', 'CoreData']
   

--- a/renderer-cloudx/CloudXRenderer.podspec
+++ b/renderer-cloudx/CloudXRenderer.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.source           = { :git => 'https://github.com/cloudx-io/cloudx-ios.git', :tag => "v#{s.version}-renderer" }
   
   s.ios.deployment_target = '15.0'
-  s.vendored_frameworks = 'CloudXRenderer.xcframework'
+  s.vendored_frameworks = 'renderer-cloudx/CloudXRenderer.xcframework'
   
   # Dependencies
   s.dependency 'CloudXCore', '1.2.1'


### PR DESCRIPTION
CocoaPods evaluates vendored_frameworks paths relative to repo root, not podspec location. Updated all podspecs to use full paths (e.g., core/CloudXCore.xcframework).