### PR TITLE
Update demo apps for 2.2.0-beta testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [2.2.0-beta] - 2026-02-25
+
+### Added
+- **IDFV Tracking** - IDFV (ifv) now included in config init and bid requests for DAU/MAU analytics
+- **Adapter Init Error Tracking** - SDK now sends error events when adapter initialization fails
+- **Win/Loss Payload Parity** - Aligned iOS win/loss notification payloads with Android
+
+### Fixed
+- **Duplicate didHideAd Callback** - Fixed fullscreen ads firing didHideAd twice on close
+- **Adapter Code Resolution** - Fixed adaptercode resolution for SDK >= 2.1 after SSP ext.cloudx migration
+- **Thread Safety** - Fixed thread safety crash in bid token dictionary construction
+- **Double Revenue Callback** - Fixed CloudX renderer test rewarded ads firing revenue callback twice
+- **Silent Failures** - Audited and fixed silent failures across core SDK
+- **Adapter Creation Errors** - Real adapter creation errors now propagate through bid waterfall
+
+### Changed
+- **JIT ViewController Resolution** - Banner/MREC ads now resolve the presenting view controller at use time instead of storing a weak reference
+- **Removed Fullscreen Force-Close Timer** - Removed the timer-based force-close mechanism for fullscreen ads
+- **Adapter Rewrites** - InMobi, Vungle, and Mintegral adapters fully rewritten
+- **Removed Dead Code** - Cleaned up dead database code, endpoint config, A/B test code, and non-deterministic tests
+
+---
+
 ## [2.1.0-beta] - 2026-02-10
 
 ### Fixed

--- a/demo-app-objc/CloudXObjCRemotePods/Views/Ad/BannerViewController.m
+++ b/demo-app-objc/CloudXObjCRemotePods/Views/Ad/BannerViewController.m
@@ -150,8 +150,7 @@
         adUnitId = _settings.bannerAdUnitId;
     }
     
-    self.bannerAd = [[CloudXCore shared] createBannerWithAdUnitId:adUnitId
-                                                      viewController:self];
+    self.bannerAd = [[CloudXCore shared] createBannerWithAdUnitId:adUnitId];
     self.bannerAd.delegate = self;
     self.bannerAd.revenueDelegate = self;
     self.bannerAd.placement = @"demo_banner";

--- a/demo-app-objc/CloudXObjCRemotePods/Views/Ad/InterstitialViewController.m
+++ b/demo-app-objc/CloudXObjCRemotePods/Views/Ad/InterstitialViewController.m
@@ -66,7 +66,11 @@
 
 - (void)viewWillDisappear:(BOOL)animated {
     [super viewWillDisappear:animated];
-    [self resetAdState];
+    // Only reset if we're actually leaving the tab — not when a fullscreen ad
+    // is presented over us (which also triggers viewWillDisappear).
+    if (!self.interstitialAd || self.isLoading) {
+        [self resetAdState];
+    }
 }
 
 - (void)dealloc {

--- a/demo-app-objc/CloudXObjCRemotePods/Views/Ad/MRECViewController.m
+++ b/demo-app-objc/CloudXObjCRemotePods/Views/Ad/MRECViewController.m
@@ -120,7 +120,7 @@
     if (_settings.mrecAdUnitId.length > 0) {
         adUnitId = _settings.mrecAdUnitId;
     }
-    self.mrecAd = [[CloudXCore shared] createMRECWithAdUnitId:adUnitId viewController:self];
+    self.mrecAd = [[CloudXCore shared] createMRECWithAdUnitId:adUnitId];
     self.mrecAd.delegate = self;
     self.mrecAd.revenueDelegate = self;
     self.mrecAd.placement = @"demo_mrec";
@@ -239,8 +239,7 @@
     [self updateStatusUIWithState:AdStateLoading];
 
     NSString *adUnitId = [self adUnitId];
-    self.mrecAd = [[CloudXCore shared] createMRECWithAdUnitId:adUnitId
-                                                 viewController:self];
+    self.mrecAd = [[CloudXCore shared] createMRECWithAdUnitId:adUnitId];
     self.mrecAd.delegate = self;
     self.mrecAd.revenueDelegate = self;
     self.mrecAd.placement = @"demo_mrec";

--- a/demo-app-objc/CloudXObjCRemotePods/Views/Ad/RewardedViewController.m
+++ b/demo-app-objc/CloudXObjCRemotePods/Views/Ad/RewardedViewController.m
@@ -64,7 +64,9 @@
 
 - (void)viewWillDisappear:(BOOL)animated {
     [super viewWillDisappear:animated];
-    [self resetAdState];
+    if (!self.rewardedAd || self.isLoading) {
+        [self resetAdState];
+    }
 }
 
 - (void)dealloc {

--- a/demo-app-objc/Podfile
+++ b/demo-app-objc/Podfile
@@ -3,11 +3,11 @@ platform :ios, '13.0'
 target 'CloudXObjCRemotePods' do
   use_frameworks! :linkage => :static
 
-  pod 'CloudXCore', :git => 'https://github.com/cloudx-io/cloudx-ios.git', :branch => 'main'
-  pod 'CloudXMetaAdapter', :git => 'https://github.com/cloudx-io/cloudx-ios.git', :branch => 'main'
-  pod 'CloudXRenderer', :git => 'https://github.com/cloudx-io/cloudx-ios.git', :branch => 'main'
-  pod 'CloudXVungleAdapter', :git => 'https://github.com/cloudx-io/cloudx-ios.git', :branch => 'main'
-  pod 'CloudXInMobiAdapter', :git => 'https://github.com/cloudx-io/cloudx-ios.git', :branch => 'main'
+  pod 'CloudXCore', :podspec => 'https://raw.githubusercontent.com/cloudx-io/cloudx-ios/main/core/CloudXCore.podspec'
+  pod 'CloudXMetaAdapter', :podspec => 'https://raw.githubusercontent.com/cloudx-io/cloudx-ios/main/adapter-meta/CloudXMetaAdapter.podspec'
+  pod 'CloudXRenderer', :podspec => 'https://raw.githubusercontent.com/cloudx-io/cloudx-ios/main/renderer-cloudx/CloudXRenderer.podspec'
+  pod 'CloudXVungleAdapter', :podspec => 'https://raw.githubusercontent.com/cloudx-io/cloudx-ios/main/adapter-vungle/CloudXVungleAdapter.podspec'
+  pod 'CloudXInMobiAdapter', :podspec => 'https://raw.githubusercontent.com/cloudx-io/cloudx-ios/main/adapter-inmobi/CloudXInMobiAdapter.podspec'
 
   target 'CloudXObjCRemotePodsTests' do
     inherit! :search_paths

--- a/demo-app-objc/Podfile
+++ b/demo-app-objc/Podfile
@@ -3,11 +3,11 @@ platform :ios, '13.0'
 target 'CloudXObjCRemotePods' do
   use_frameworks! :linkage => :static
 
-  pod 'CloudXCore', '2.1.0-beta'
-  pod 'CloudXMetaAdapter', '2.1.0-beta'
-  pod 'CloudXRenderer', '2.1.0-beta'
-  pod 'CloudXVungleAdapter', '2.1.0-beta'
-  pod 'CloudXInMobiAdapter', '2.1.0-beta'
+  pod 'CloudXCore', :git => 'https://github.com/cloudx-io/cloudx-ios.git', :branch => 'main'
+  pod 'CloudXMetaAdapter', :git => 'https://github.com/cloudx-io/cloudx-ios.git', :branch => 'main'
+  pod 'CloudXRenderer', :git => 'https://github.com/cloudx-io/cloudx-ios.git', :branch => 'main'
+  pod 'CloudXVungleAdapter', :git => 'https://github.com/cloudx-io/cloudx-ios.git', :branch => 'main'
+  pod 'CloudXInMobiAdapter', :git => 'https://github.com/cloudx-io/cloudx-ios.git', :branch => 'main'
 
   target 'CloudXObjCRemotePodsTests' do
     inherit! :search_paths

--- a/demo-app-objc/Podfile
+++ b/demo-app-objc/Podfile
@@ -3,11 +3,11 @@ platform :ios, '13.0'
 target 'CloudXObjCRemotePods' do
   use_frameworks! :linkage => :static
 
-  pod 'CloudXCore', :podspec => 'https://raw.githubusercontent.com/cloudx-io/cloudx-ios/main/core/CloudXCore.podspec'
-  pod 'CloudXMetaAdapter', :podspec => 'https://raw.githubusercontent.com/cloudx-io/cloudx-ios/main/adapter-meta/CloudXMetaAdapter.podspec'
-  pod 'CloudXRenderer', :podspec => 'https://raw.githubusercontent.com/cloudx-io/cloudx-ios/main/renderer-cloudx/CloudXRenderer.podspec'
-  pod 'CloudXVungleAdapter', :podspec => 'https://raw.githubusercontent.com/cloudx-io/cloudx-ios/main/adapter-vungle/CloudXVungleAdapter.podspec'
-  pod 'CloudXInMobiAdapter', :podspec => 'https://raw.githubusercontent.com/cloudx-io/cloudx-ios/main/adapter-inmobi/CloudXInMobiAdapter.podspec'
+  pod 'CloudXCore', :podspec => 'https://raw.githubusercontent.com/cloudx-io/cloudx-ios/v2.2.0-beta-core/core/CloudXCore.podspec'
+  pod 'CloudXMetaAdapter', :podspec => 'https://raw.githubusercontent.com/cloudx-io/cloudx-ios/v2.2.0-beta-meta/adapter-meta/CloudXMetaAdapter.podspec'
+  pod 'CloudXRenderer', :podspec => 'https://raw.githubusercontent.com/cloudx-io/cloudx-ios/v2.2.0-beta-renderer/renderer-cloudx/CloudXRenderer.podspec'
+  pod 'CloudXVungleAdapter', :podspec => 'https://raw.githubusercontent.com/cloudx-io/cloudx-ios/v2.2.0-beta-vungle/adapter-vungle/CloudXVungleAdapter.podspec'
+  pod 'CloudXInMobiAdapter', :podspec => 'https://raw.githubusercontent.com/cloudx-io/cloudx-ios/v2.2.0-beta-inmobi/adapter-inmobi/CloudXInMobiAdapter.podspec'
 
   target 'CloudXObjCRemotePodsTests' do
     inherit! :search_paths

--- a/demo-app-objc/Podfile.lock
+++ b/demo-app-objc/Podfile.lock
@@ -1,48 +1,55 @@
 PODS:
-  - CloudXCore (2.1.0-beta)
-  - CloudXInMobiAdapter (2.1.0-beta):
-    - CloudXCore (= 2.1.0-beta)
+  - CloudXCore (2.2.0-beta)
+  - CloudXInMobiAdapter (2.2.0-beta):
+    - CloudXCore (= 2.2.0-beta)
     - InMobiSDK (~> 11.1)
-  - CloudXMetaAdapter (2.1.0-beta):
-    - CloudXCore (= 2.1.0-beta)
+  - CloudXMetaAdapter (2.2.0-beta):
+    - CloudXCore (= 2.2.0-beta)
     - FBAudienceNetwork (~> 6.21.0)
-  - CloudXRenderer (2.1.0-beta):
-    - CloudXCore (= 2.1.0-beta)
-  - CloudXVungleAdapter (2.1.0-beta):
-    - CloudXCore (= 2.1.0-beta)
+  - CloudXRenderer (2.2.0-beta):
+    - CloudXCore (= 2.2.0-beta)
+  - CloudXVungleAdapter (2.2.0-beta):
+    - CloudXCore (= 2.2.0-beta)
     - VungleAds (~> 7.6.0)
-  - FBAudienceNetwork (6.21.0)
+  - FBAudienceNetwork (6.21.1)
   - InMobiSDK (11.1.1)
   - VungleAds (7.6.3)
 
 DEPENDENCIES:
-  - CloudXCore (= 2.1.0-beta)
-  - CloudXInMobiAdapter (= 2.1.0-beta)
-  - CloudXMetaAdapter (= 2.1.0-beta)
-  - CloudXRenderer (= 2.1.0-beta)
-  - CloudXVungleAdapter (= 2.1.0-beta)
+  - CloudXCore (from `https://raw.githubusercontent.com/cloudx-io/cloudx-ios/v2.2.0-beta-core/core/CloudXCore.podspec`)
+  - CloudXInMobiAdapter (from `https://raw.githubusercontent.com/cloudx-io/cloudx-ios/v2.2.0-beta-inmobi/adapter-inmobi/CloudXInMobiAdapter.podspec`)
+  - CloudXMetaAdapter (from `https://raw.githubusercontent.com/cloudx-io/cloudx-ios/v2.2.0-beta-meta/adapter-meta/CloudXMetaAdapter.podspec`)
+  - CloudXRenderer (from `https://raw.githubusercontent.com/cloudx-io/cloudx-ios/v2.2.0-beta-renderer/renderer-cloudx/CloudXRenderer.podspec`)
+  - CloudXVungleAdapter (from `https://raw.githubusercontent.com/cloudx-io/cloudx-ios/v2.2.0-beta-vungle/adapter-vungle/CloudXVungleAdapter.podspec`)
 
 SPEC REPOS:
   trunk:
-    - CloudXCore
-    - CloudXInMobiAdapter
-    - CloudXMetaAdapter
-    - CloudXRenderer
-    - CloudXVungleAdapter
     - FBAudienceNetwork
     - InMobiSDK
     - VungleAds
 
+EXTERNAL SOURCES:
+  CloudXCore:
+    :podspec: https://raw.githubusercontent.com/cloudx-io/cloudx-ios/v2.2.0-beta-core/core/CloudXCore.podspec
+  CloudXInMobiAdapter:
+    :podspec: https://raw.githubusercontent.com/cloudx-io/cloudx-ios/v2.2.0-beta-inmobi/adapter-inmobi/CloudXInMobiAdapter.podspec
+  CloudXMetaAdapter:
+    :podspec: https://raw.githubusercontent.com/cloudx-io/cloudx-ios/v2.2.0-beta-meta/adapter-meta/CloudXMetaAdapter.podspec
+  CloudXRenderer:
+    :podspec: https://raw.githubusercontent.com/cloudx-io/cloudx-ios/v2.2.0-beta-renderer/renderer-cloudx/CloudXRenderer.podspec
+  CloudXVungleAdapter:
+    :podspec: https://raw.githubusercontent.com/cloudx-io/cloudx-ios/v2.2.0-beta-vungle/adapter-vungle/CloudXVungleAdapter.podspec
+
 SPEC CHECKSUMS:
-  CloudXCore: 47c378aa695ef74738295dc07403e050a95f259c
-  CloudXInMobiAdapter: 55ac2cbfd0ecb9417d8d9c3b7082fc45092c36de
-  CloudXMetaAdapter: 4fea43870002b7df57178bc70a98a7362e948da2
-  CloudXRenderer: e19a1e17e5f97cf5938be5f61749d27cc88776f0
-  CloudXVungleAdapter: 007ea48145bb4818a8624e1de0b4efb5bc6b822c
-  FBAudienceNetwork: f4ab9e073ab98c884dbdb5ffe7c861272b380bc2
+  CloudXCore: 4bbcbbd7af2f879cfcf401d53e81593915860c3c
+  CloudXInMobiAdapter: 33093398a4dda64057f36d6eb5f14b1c97a68958
+  CloudXMetaAdapter: 6613aefcddc0896d06ce18496cdcca1a624948e4
+  CloudXRenderer: 64d4fe1c5669df2f628e7a4f4bf6d32e96326279
+  CloudXVungleAdapter: b6d5a7777f79f0169d0f223f72ddc40e95156d06
+  FBAudienceNetwork: 85d18a65c9e35bc426bd4664cf3ae2a1172d7b60
   InMobiSDK: 4642fb34a961980ab94a1ac460c6e16e113498e6
   VungleAds: 40e87d1eaba17ac818b0f94461fd8ed21ad768dc
 
-PODFILE CHECKSUM: d4159f178abd2da50ccaddb1eb874680c481d778
+PODFILE CHECKSUM: 2f6c45b091820f3f596cbaa4f4569f06e726ea27
 
 COCOAPODS: 1.16.2

--- a/demo-app-swift/CloudXSwiftRemotePods/Views/Ad/BannerViewController.swift
+++ b/demo-app-swift/CloudXSwiftRemotePods/Views/Ad/BannerViewController.swift
@@ -105,7 +105,7 @@ class BannerViewController: BaseAdViewController {
         
         // Create banner ad with adUnitId from config
         let adUnitId = CLXDemoConfigManager.sharedManager.currentConfig.bannerAdUnitId
-        bannerAd = cloudX.createBanner(adUnitId: adUnitId, viewController: self)
+        bannerAd = cloudX.createBanner(adUnitId: adUnitId)
         bannerAd?.delegate = self
         bannerAd?.revenueDelegate = self
         bannerAd?.placement = "demo_banner"

--- a/demo-app-swift/CloudXSwiftRemotePods/Views/Ad/BannerViewController.swift
+++ b/demo-app-swift/CloudXSwiftRemotePods/Views/Ad/BannerViewController.swift
@@ -103,8 +103,10 @@ class BannerViewController: BaseAdViewController {
     private func createAndAddBannerToView() {
         guard bannerAd == nil else { return }
         
-        // Create banner ad with adUnitId from config
-        let adUnitId = CLXDemoConfigManager.sharedManager.currentConfig.bannerAdUnitId
+        var adUnitId = CLXDemoConfigManager.sharedManager.currentConfig.bannerAdUnitId
+        if !settings.bannerAdUnitId.isEmpty {
+            adUnitId = settings.bannerAdUnitId
+        }
         bannerAd = cloudX.createBanner(adUnitId: adUnitId)
         bannerAd?.delegate = self
         bannerAd?.revenueDelegate = self

--- a/demo-app-swift/CloudXSwiftRemotePods/Views/Ad/InterstitialViewController.swift
+++ b/demo-app-swift/CloudXSwiftRemotePods/Views/Ad/InterstitialViewController.swift
@@ -105,7 +105,11 @@ class InterstitialViewController: BaseAdViewController {
     
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
-        resetAdState()
+        // Only reset if we're actually leaving the tab — not when a fullscreen ad
+        // is presented over us (which also triggers viewWillDisappear).
+        if interstitialAd == nil || isLoading {
+            resetAdState()
+        }
     }
     
     deinit {
@@ -198,8 +202,8 @@ extension InterstitialViewController: CLXInterstitialDelegate, CLXAdRevenueDeleg
         updateStatusUI(state: AdState.noAd)
         
         DispatchQueue.main.async { [weak self] in
-            let errorMessage = error.localizedDescription
-            self?.showAlert(title: "Interstitial Ad Error", message: errorMessage)
+            let errorMessage = (error as NSError).detailedDemoDescription
+            self?.showAlert(title: "Interstitial Ad Load Failed", message: errorMessage)
             self?.interstitialAd = nil
         }
     }
@@ -214,8 +218,8 @@ extension InterstitialViewController: CLXInterstitialDelegate, CLXAdRevenueDeleg
         
         DispatchQueue.main.async { [weak self] in
             self?.interstitialAd = nil
-            let errorMessage = error.localizedDescription
-            self?.showAlert(title: "Interstitial Ad Error", message: errorMessage)
+            let errorMessage = (error as NSError).detailedDemoDescription
+            self?.showAlert(title: "Interstitial Ad Show Failed", message: errorMessage)
         }
     }
     

--- a/demo-app-swift/CloudXSwiftRemotePods/Views/Ad/MRECViewController.swift
+++ b/demo-app-swift/CloudXSwiftRemotePods/Views/Ad/MRECViewController.swift
@@ -112,7 +112,7 @@ class MRECViewController: BaseAdViewController, CLXBannerDelegate, CLXAdRevenueD
         if !settings.mrecAdUnitId.isEmpty {
             adUnitId = settings.mrecAdUnitId
         }
-        mrecAd = CloudXCore.shared.createMREC(adUnitId: adUnitId, viewController: self)
+        mrecAd = CloudXCore.shared.createMREC(adUnitId: adUnitId)
         mrecAd?.delegate = self
         mrecAd?.revenueDelegate = self
         mrecAd?.placement = "demo_mrec"
@@ -184,8 +184,7 @@ class MRECViewController: BaseAdViewController, CLXBannerDelegate, CLXAdRevenueD
         updateStatusUI(state: .loading)
 
         let adUnitId = self.adUnitId
-        mrecAd = CloudXCore.shared.createMREC(adUnitId: adUnitId,
-                                            viewController: self)
+        mrecAd = CloudXCore.shared.createMREC(adUnitId: adUnitId)
         mrecAd?.delegate = self
         mrecAd?.revenueDelegate = self
         

--- a/demo-app-swift/CloudXSwiftRemotePods/Views/Ad/MRECViewController.swift
+++ b/demo-app-swift/CloudXSwiftRemotePods/Views/Ad/MRECViewController.swift
@@ -213,8 +213,8 @@ class MRECViewController: BaseAdViewController, CLXBannerDelegate, CLXAdRevenueD
         updateStatusUI(state: .noAd)
         
         DispatchQueue.main.async { [weak self] in
-            let errorMessage = error.localizedDescription
-            self?.showAlert(title: "MREC Error", message: errorMessage)
+            let errorMessage = (error as NSError).detailedDemoDescription
+            self?.showAlert(title: "MREC Ad Load Failed", message: errorMessage)
         }
     }
     

--- a/demo-app-swift/CloudXSwiftRemotePods/Views/Ad/RewardedViewController.swift
+++ b/demo-app-swift/CloudXSwiftRemotePods/Views/Ad/RewardedViewController.swift
@@ -61,7 +61,9 @@ class RewardedViewController: BaseAdViewController, CLXRewardedDelegate, CLXAdRe
     
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
-        resetAdState()
+        if rewardedAd == nil || isLoading {
+            resetAdState()
+        }
     }
     
     deinit {

--- a/demo-app-swift/Podfile
+++ b/demo-app-swift/Podfile
@@ -3,11 +3,11 @@ platform :ios, '13.0'
 target 'CloudXSwiftRemotePods' do
   use_frameworks! :linkage => :static
 
-  pod 'CloudXCore', :podspec => 'https://raw.githubusercontent.com/cloudx-io/cloudx-ios/main/core/CloudXCore.podspec'
-  pod 'CloudXMetaAdapter', :podspec => 'https://raw.githubusercontent.com/cloudx-io/cloudx-ios/main/adapter-meta/CloudXMetaAdapter.podspec'
-  pod 'CloudXRenderer', :podspec => 'https://raw.githubusercontent.com/cloudx-io/cloudx-ios/main/renderer-cloudx/CloudXRenderer.podspec'
-  pod 'CloudXVungleAdapter', :podspec => 'https://raw.githubusercontent.com/cloudx-io/cloudx-ios/main/adapter-vungle/CloudXVungleAdapter.podspec'
-  pod 'CloudXInMobiAdapter', :podspec => 'https://raw.githubusercontent.com/cloudx-io/cloudx-ios/main/adapter-inmobi/CloudXInMobiAdapter.podspec'
+  pod 'CloudXCore', :podspec => 'https://raw.githubusercontent.com/cloudx-io/cloudx-ios/v2.2.0-beta-core/core/CloudXCore.podspec'
+  pod 'CloudXMetaAdapter', :podspec => 'https://raw.githubusercontent.com/cloudx-io/cloudx-ios/v2.2.0-beta-meta/adapter-meta/CloudXMetaAdapter.podspec'
+  pod 'CloudXRenderer', :podspec => 'https://raw.githubusercontent.com/cloudx-io/cloudx-ios/v2.2.0-beta-renderer/renderer-cloudx/CloudXRenderer.podspec'
+  pod 'CloudXVungleAdapter', :podspec => 'https://raw.githubusercontent.com/cloudx-io/cloudx-ios/v2.2.0-beta-vungle/adapter-vungle/CloudXVungleAdapter.podspec'
+  pod 'CloudXInMobiAdapter', :podspec => 'https://raw.githubusercontent.com/cloudx-io/cloudx-ios/v2.2.0-beta-inmobi/adapter-inmobi/CloudXInMobiAdapter.podspec'
 
   target 'CloudXSwiftRemotePodsTests' do
     inherit! :search_paths

--- a/demo-app-swift/Podfile
+++ b/demo-app-swift/Podfile
@@ -3,11 +3,11 @@ platform :ios, '13.0'
 target 'CloudXSwiftRemotePods' do
   use_frameworks! :linkage => :static
 
-  pod 'CloudXCore', :git => 'https://github.com/cloudx-io/cloudx-ios.git', :branch => 'main'
-  pod 'CloudXMetaAdapter', :git => 'https://github.com/cloudx-io/cloudx-ios.git', :branch => 'main'
-  pod 'CloudXRenderer', :git => 'https://github.com/cloudx-io/cloudx-ios.git', :branch => 'main'
-  pod 'CloudXVungleAdapter', :git => 'https://github.com/cloudx-io/cloudx-ios.git', :branch => 'main'
-  pod 'CloudXInMobiAdapter', :git => 'https://github.com/cloudx-io/cloudx-ios.git', :branch => 'main'
+  pod 'CloudXCore', :podspec => 'https://raw.githubusercontent.com/cloudx-io/cloudx-ios/main/core/CloudXCore.podspec'
+  pod 'CloudXMetaAdapter', :podspec => 'https://raw.githubusercontent.com/cloudx-io/cloudx-ios/main/adapter-meta/CloudXMetaAdapter.podspec'
+  pod 'CloudXRenderer', :podspec => 'https://raw.githubusercontent.com/cloudx-io/cloudx-ios/main/renderer-cloudx/CloudXRenderer.podspec'
+  pod 'CloudXVungleAdapter', :podspec => 'https://raw.githubusercontent.com/cloudx-io/cloudx-ios/main/adapter-vungle/CloudXVungleAdapter.podspec'
+  pod 'CloudXInMobiAdapter', :podspec => 'https://raw.githubusercontent.com/cloudx-io/cloudx-ios/main/adapter-inmobi/CloudXInMobiAdapter.podspec'
 
   target 'CloudXSwiftRemotePodsTests' do
     inherit! :search_paths

--- a/demo-app-swift/Podfile
+++ b/demo-app-swift/Podfile
@@ -3,11 +3,11 @@ platform :ios, '13.0'
 target 'CloudXSwiftRemotePods' do
   use_frameworks! :linkage => :static
 
-  pod 'CloudXCore', '2.1.0-beta'
-  pod 'CloudXMetaAdapter', '2.1.0-beta'
-  pod 'CloudXRenderer', '2.1.0-beta'
-  pod 'CloudXVungleAdapter', '2.1.0-beta'
-  pod 'CloudXInMobiAdapter', '2.1.0-beta'
+  pod 'CloudXCore', :git => 'https://github.com/cloudx-io/cloudx-ios.git', :branch => 'main'
+  pod 'CloudXMetaAdapter', :git => 'https://github.com/cloudx-io/cloudx-ios.git', :branch => 'main'
+  pod 'CloudXRenderer', :git => 'https://github.com/cloudx-io/cloudx-ios.git', :branch => 'main'
+  pod 'CloudXVungleAdapter', :git => 'https://github.com/cloudx-io/cloudx-ios.git', :branch => 'main'
+  pod 'CloudXInMobiAdapter', :git => 'https://github.com/cloudx-io/cloudx-ios.git', :branch => 'main'
 
   target 'CloudXSwiftRemotePodsTests' do
     inherit! :search_paths

--- a/demo-app-swift/Podfile.lock
+++ b/demo-app-swift/Podfile.lock
@@ -1,48 +1,55 @@
 PODS:
-  - CloudXCore (2.1.0-beta)
-  - CloudXInMobiAdapter (2.1.0-beta):
-    - CloudXCore (= 2.1.0-beta)
+  - CloudXCore (2.2.0-beta)
+  - CloudXInMobiAdapter (2.2.0-beta):
+    - CloudXCore (= 2.2.0-beta)
     - InMobiSDK (~> 11.1)
-  - CloudXMetaAdapter (2.1.0-beta):
-    - CloudXCore (= 2.1.0-beta)
+  - CloudXMetaAdapter (2.2.0-beta):
+    - CloudXCore (= 2.2.0-beta)
     - FBAudienceNetwork (~> 6.21.0)
-  - CloudXRenderer (2.1.0-beta):
-    - CloudXCore (= 2.1.0-beta)
-  - CloudXVungleAdapter (2.1.0-beta):
-    - CloudXCore (= 2.1.0-beta)
+  - CloudXRenderer (2.2.0-beta):
+    - CloudXCore (= 2.2.0-beta)
+  - CloudXVungleAdapter (2.2.0-beta):
+    - CloudXCore (= 2.2.0-beta)
     - VungleAds (~> 7.6.0)
-  - FBAudienceNetwork (6.21.0)
+  - FBAudienceNetwork (6.21.1)
   - InMobiSDK (11.1.1)
   - VungleAds (7.6.3)
 
 DEPENDENCIES:
-  - CloudXCore (= 2.1.0-beta)
-  - CloudXInMobiAdapter (= 2.1.0-beta)
-  - CloudXMetaAdapter (= 2.1.0-beta)
-  - CloudXRenderer (= 2.1.0-beta)
-  - CloudXVungleAdapter (= 2.1.0-beta)
+  - CloudXCore (from `https://raw.githubusercontent.com/cloudx-io/cloudx-ios/v2.2.0-beta-core/core/CloudXCore.podspec`)
+  - CloudXInMobiAdapter (from `https://raw.githubusercontent.com/cloudx-io/cloudx-ios/v2.2.0-beta-inmobi/adapter-inmobi/CloudXInMobiAdapter.podspec`)
+  - CloudXMetaAdapter (from `https://raw.githubusercontent.com/cloudx-io/cloudx-ios/v2.2.0-beta-meta/adapter-meta/CloudXMetaAdapter.podspec`)
+  - CloudXRenderer (from `https://raw.githubusercontent.com/cloudx-io/cloudx-ios/v2.2.0-beta-renderer/renderer-cloudx/CloudXRenderer.podspec`)
+  - CloudXVungleAdapter (from `https://raw.githubusercontent.com/cloudx-io/cloudx-ios/v2.2.0-beta-vungle/adapter-vungle/CloudXVungleAdapter.podspec`)
 
 SPEC REPOS:
   trunk:
-    - CloudXCore
-    - CloudXInMobiAdapter
-    - CloudXMetaAdapter
-    - CloudXRenderer
-    - CloudXVungleAdapter
     - FBAudienceNetwork
     - InMobiSDK
     - VungleAds
 
+EXTERNAL SOURCES:
+  CloudXCore:
+    :podspec: https://raw.githubusercontent.com/cloudx-io/cloudx-ios/v2.2.0-beta-core/core/CloudXCore.podspec
+  CloudXInMobiAdapter:
+    :podspec: https://raw.githubusercontent.com/cloudx-io/cloudx-ios/v2.2.0-beta-inmobi/adapter-inmobi/CloudXInMobiAdapter.podspec
+  CloudXMetaAdapter:
+    :podspec: https://raw.githubusercontent.com/cloudx-io/cloudx-ios/v2.2.0-beta-meta/adapter-meta/CloudXMetaAdapter.podspec
+  CloudXRenderer:
+    :podspec: https://raw.githubusercontent.com/cloudx-io/cloudx-ios/v2.2.0-beta-renderer/renderer-cloudx/CloudXRenderer.podspec
+  CloudXVungleAdapter:
+    :podspec: https://raw.githubusercontent.com/cloudx-io/cloudx-ios/v2.2.0-beta-vungle/adapter-vungle/CloudXVungleAdapter.podspec
+
 SPEC CHECKSUMS:
-  CloudXCore: 47c378aa695ef74738295dc07403e050a95f259c
-  CloudXInMobiAdapter: 55ac2cbfd0ecb9417d8d9c3b7082fc45092c36de
-  CloudXMetaAdapter: 4fea43870002b7df57178bc70a98a7362e948da2
-  CloudXRenderer: e19a1e17e5f97cf5938be5f61749d27cc88776f0
-  CloudXVungleAdapter: 007ea48145bb4818a8624e1de0b4efb5bc6b822c
-  FBAudienceNetwork: f4ab9e073ab98c884dbdb5ffe7c861272b380bc2
+  CloudXCore: 4bbcbbd7af2f879cfcf401d53e81593915860c3c
+  CloudXInMobiAdapter: 33093398a4dda64057f36d6eb5f14b1c97a68958
+  CloudXMetaAdapter: 6613aefcddc0896d06ce18496cdcca1a624948e4
+  CloudXRenderer: 64d4fe1c5669df2f628e7a4f4bf6d32e96326279
+  CloudXVungleAdapter: b6d5a7777f79f0169d0f223f72ddc40e95156d06
+  FBAudienceNetwork: 85d18a65c9e35bc426bd4664cf3ae2a1172d7b60
   InMobiSDK: 4642fb34a961980ab94a1ac460c6e16e113498e6
   VungleAds: 40e87d1eaba17ac818b0f94461fd8ed21ad768dc
 
-PODFILE CHECKSUM: edc5180736e7dab6201aa863f6e733f0b114c34f
+PODFILE CHECKSUM: b46f16c507374637504c3ef6f312c962d8ef96b1
 
 COCOAPODS: 1.16.2


### PR DESCRIPTION
## Summary

- **Podfiles**: Both ObjC and Swift demo app Podfiles updated to use `:podspec` format pointing to `v2.2.0-beta-*` component tags for pre-release testing.
- **Deprecated API migration**: Updated all banner and MREC creation calls from the deprecated `viewController:` overloads (`createBannerWithAdUnitId:viewController:` / `createMRECWithAdUnitId:viewController:`) to the new JIT-resolution APIs (`createBannerWithAdUnitId:` / `createMRECWithAdUnitId:`).
- **Fullscreen ad lifecycle fix**: Fixed premature ad deallocation in `viewWillDisappear` for interstitial and rewarded view controllers (both ObjC and Swift). The old code called `resetAdState()` unconditionally, which nilled the ad object while the fullscreen ad was still presented — preventing all delegate callbacks (`didDisplayAd`, `didHideAd`, `didClickAd`, `didPayRevenue`) from firing.
- **Swift demo app parity**: Aligned Swift demo app with ObjC implementation — added `bannerAdUnitId` settings override in `BannerViewController.swift`, and switched error alerts in `MRECViewController.swift` and `InterstitialViewController.swift` to use `detailedDemoDescription` for richer error details.
- **Public CHANGELOG**: Added `2.2.0-beta` entry.

## Testing performed

### ObjC Demo App — All ad types verified
- **Banner**: Loaded, displayed, revenue callback fired, clicked — all delegate callbacks present in logs
- **MREC**: Loaded, displayed, revenue callback fired — all delegate callbacks present in logs
- **Interstitial**: Loaded, displayed, clicked, hidden — `didDisplayAd`, `didClickAd`, `didPayRevenue`, `didHideAd` all firing correctly
- **Rewarded**: Loaded, displayed, reward granted, hidden — `didDisplayAd`, `didRewardUser`, `didPayRevenue`, `didHideAd` all firing correctly
- SDK version confirmed as `2.2.0-beta` in logs
- IDFV tracking confirmed enabled
- All adapters initializing successfully
- Win/loss notifications confirmed firing

### Swift Demo App — All ad types verified
- **Banner**: Loaded with settings ad unit ID override working correctly
- **MREC**: Loaded, error alerts showing `detailedDemoDescription`
- **Interstitial**: Full lifecycle working — no premature deallocation, error alerts with detailed descriptions
- **Rewarded**: Full lifecycle working — no premature deallocation

### Bug found and fixed during testing
Fullscreen ads (interstitial + rewarded) were losing all delegate callbacks in both demo apps. Root cause: `viewWillDisappear` fires when a fullscreen ad is presented over the view controller, and `resetAdState()` was nilling the ad object immediately. Fixed by guarding cleanup to only run when the ad is nil or still loading.