### PR TITLE
Add Claude PR review workflow

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,23 @@
+name: Claude PR Review
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      actions: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          prompt: "Review this PR for bugs, security issues, and code quality. Post your findings as a PR comment. Be concise."
+          track_progress: "true"


### PR DESCRIPTION
## Summary

- Adds `claude-review.yml` GitHub Actions workflow, mirroring the existing setup in the iOS-private and Android repos
- Triggers on PR open, reopen, and synchronize events
- Uses the org-level `ANTHROPIC_API_KEY` secret

## Test plan

- [ ] Verify the workflow runs on the next PR after merge

Made with [Cursor](https://cursor.com)