### PR TITLE
Fix incorrect error code mapping and MREC failure UI in demo apps

### DIFF
--- a/demo-app-objc/CloudXObjCRemotePods/Configuration/NSError+DemoDescription.m
+++ b/demo-app-objc/CloudXObjCRemotePods/Configuration/NSError+DemoDescription.m
@@ -52,55 +52,47 @@
     }
     
     // Add kill switch specific message
-    if (self.code == 105 || self.code == 308) { // CLXErrorCodeSDKDisabled or CLXErrorCodeAdsDisabled
+    if (self.code == 204 || self.code == 301) { // CLXErrorCodeSDKDisabled or CLXErrorCodeAdsDisabled
         [description appendString:@"\n⚠️ Kill Switch Active: SDK or ads have been remotely disabled via traffic control."];
     }
-    
+
     return [description copy];
 }
 
 - (NSString *)cloudXErrorCodeName:(NSInteger)code {
-    // Map CloudX error codes to human-readable names
     switch (code) {
-        // INITIALIZATION ERRORS (100-199)
-        case 100: return @"Not Initialized";
-        case 101: return @"Initialization In Progress";
-        case 102: return @"No Adapters Found";
-        case 103: return @"Initialization Timeout";
-        case 104: return @"Invalid App Key";
-        case 105: return @"SDK Disabled (Kill Switch)";
-        
-        // NETWORK ERRORS (200-299)
-        case 200: return @"Network Error";
-        case 201: return @"Network Timeout";
-        case 202: return @"Invalid Response";
-        case 203: return @"Server Error";
-        
+        // GENERAL ERRORS (0)
+        case 0: return @"Internal Error";
+
+        // NETWORK ERRORS (100-199)
+        case 100: return @"Network Error";
+        case 101: return @"Network Timeout";
+        case 102: return @"Server Error";
+        case 103: return @"Client Error";
+        case 104: return @"Too Many Requests";
+        case 105: return @"Invalid Response";
+        case 106: return @"No Connection";
+
+        // INITIALIZATION ERRORS (200-299)
+        case 200: return @"Not Initialized";
+        case 201: return @"No Adapters Found";
+        case 202: return @"No Networks Configured";
+        case 203: return @"Invalid App Key";
+        case 204: return @"SDK Disabled (Kill Switch)";
+
         // AD REQUEST/LOADING ERRORS (300-399)
-        case 300: return @"No Fill";
-        case 301: return @"Invalid Request";
-        case 302: return @"Invalid Ad Unit";
-        case 303: return @"Load Timeout";
+        case 300: return @"Invalid Ad Unit";
+        case 301: return @"Ads Disabled (Kill Switch)";
+        case 302: return @"No Fill";
         case 304: return @"Load Failed";
-        case 305: return @"Invalid Ad";
-        case 306: return @"Too Many Requests";
-        case 307: return @"Request Cancelled";
-        case 308: return @"Ads Disabled (Kill Switch)";
-        
+
         // AD DISPLAY/SHOW ERRORS (400-499)
         case 400: return @"Ad Not Ready";
-        case 401: return @"Ad Already Shown";
-        case 402: return @"Ad Expired";
-        case 403: return @"Invalid View Controller";
-        case 404: return @"Show Failed";
-        
+        case 401: return @"Ad Already Showing";
+
         // CONFIGURATION/SETUP ERRORS (500-599)
-        case 500: return @"Invalid Ad Unit";
-        case 501: return @"Permission Denied";
-        case 502: return @"Unsupported Ad Format";
-        case 503: return @"Invalid Banner View";
-        case 504: return @"Invalid Native View";
-        
+        case 500: return @"Invalid Native View";
+
         default: return nil;
     }
 }

--- a/demo-app-objc/CloudXObjCRemotePods/Views/Ad/MRECViewController.m
+++ b/demo-app-objc/CloudXObjCRemotePods/Views/Ad/MRECViewController.m
@@ -191,6 +191,7 @@
 - (void)didFailToLoadAd:(NSString *)adUnitId error:(CLXError *)error {
     [[DemoAppLogger sharedInstance] logMessage:[NSString stringWithFormat:@"❌ MREC failed to load (%@) - Error: %@", adUnitId, error ? error.localizedDescription : @"Unknown error"]];
     self.isLoading = NO;
+    [self updateStatusUIWithState:AdStateNoAd];
     
     dispatch_async(dispatch_get_main_queue(), ^{
         NSString *errorMessage = error ? [error detailedDemoDescription] : @"Unknown error occurred";

--- a/demo-app-swift/CloudXSwiftRemotePods/Extensions/NSError+DemoDescription.swift
+++ b/demo-app-swift/CloudXSwiftRemotePods/Extensions/NSError+DemoDescription.swift
@@ -46,55 +46,48 @@ extension NSError {
         }
         
         // Add kill switch specific message
-        if self.code == 105 || self.code == 308 { // CLXErrorCodeSDKDisabled or CLXErrorCodeAdsDisabled
+        if self.code == 204 || self.code == 301 { // CLXErrorCodeSDKDisabled or CLXErrorCodeAdsDisabled
             description += "\n⚠️ Kill Switch Active: SDK or ads have been remotely disabled via traffic control."
         }
-        
+
         return description
     }
-    
+
     /// Maps CloudX error codes to human-readable names
     private func cloudXErrorCodeName(_ code: Int) -> String? {
         switch code {
-        // INITIALIZATION ERRORS (100-199)
-        case 100: return "Not Initialized"
-        case 101: return "Initialization In Progress"
-        case 102: return "No Adapters Found"
-        case 103: return "Initialization Timeout"
-        case 104: return "Invalid App Key"
-        case 105: return "SDK Disabled (Kill Switch)"
-            
-        // NETWORK ERRORS (200-299)
-        case 200: return "Network Error"
-        case 201: return "Network Timeout"
-        case 202: return "Invalid Response"
-        case 203: return "Server Error"
-            
+        // GENERAL ERRORS (0)
+        case 0: return "Internal Error"
+
+        // NETWORK ERRORS (100-199)
+        case 100: return "Network Error"
+        case 101: return "Network Timeout"
+        case 102: return "Server Error"
+        case 103: return "Client Error"
+        case 104: return "Too Many Requests"
+        case 105: return "Invalid Response"
+        case 106: return "No Connection"
+
+        // INITIALIZATION ERRORS (200-299)
+        case 200: return "Not Initialized"
+        case 201: return "No Adapters Found"
+        case 202: return "No Networks Configured"
+        case 203: return "Invalid App Key"
+        case 204: return "SDK Disabled (Kill Switch)"
+
         // AD REQUEST/LOADING ERRORS (300-399)
-        case 300: return "No Fill"
-        case 301: return "Invalid Request"
-        case 302: return "Invalid Ad Unit"
-        case 303: return "Load Timeout"
+        case 300: return "Invalid Ad Unit"
+        case 301: return "Ads Disabled (Kill Switch)"
+        case 302: return "No Fill"
         case 304: return "Load Failed"
-        case 305: return "Invalid Ad"
-        case 306: return "Too Many Requests"
-        case 307: return "Request Cancelled"
-        case 308: return "Ads Disabled (Kill Switch)"
-            
+
         // AD DISPLAY/SHOW ERRORS (400-499)
         case 400: return "Ad Not Ready"
-        case 401: return "Ad Already Shown"
-        case 402: return "Ad Expired"
-        case 403: return "Invalid View Controller"
-        case 404: return "Show Failed"
-            
+        case 401: return "Ad Already Showing"
+
         // CONFIGURATION/SETUP ERRORS (500-599)
-        case 500: return "Invalid Ad Unit"
-        case 501: return "Permission Denied"
-        case 502: return "Unsupported Ad Format"
-        case 503: return "Invalid Banner View"
-        case 504: return "Invalid Native View"
-            
+        case 500: return "Invalid Native View"
+
         default: return nil
         }
     }


### PR DESCRIPTION
## Summary
- **Fix error code mapping**: The public demo apps' `NSError+DemoDescription` had error code ranges that didn't match the actual SDK (`CLXError.h`). Network errors (100-199) and initialization errors (200-299) were swapped, and ad request codes 300-302 were mislabeled — causing a "No Fill" (code 302) to display as "Invalid Ad Unit" in alerts.
- **Fix MREC status label**: The ObjC demo app's MREC view controller did not update the status label on load failure, leaving it stuck on yellow "Loading Ad..." instead of transitioning to the failure state.
- **Align with internal demo apps**: Both public demo apps (ObjC + Swift) now use the same correct mapping as the private/internal demo apps.

## Test plan
- [ ] Load an MREC ad that returns no fill — verify alert says "No Fill" (not "Invalid Ad Unit")
- [ ] Verify MREC status label turns red on load failure (not stuck on yellow)
- [ ] Trigger a kill switch scenario — verify the kill switch message appears for codes 204/301


Made with [Cursor](https://cursor.com)