### PR TITLE
Add deep link routing and launch argument automation to public demo apps

### DIFF
--- a/demo-app-objc/CloudXObjCRemotePods/AppDelegate.m
+++ b/demo-app-objc/CloudXObjCRemotePods/AppDelegate.m
@@ -11,6 +11,7 @@
 #import <AdSupport/AdSupport.h>
 #import "DemoAppLogger.h"
 #import "AdDemoTabViewController.h"
+#import "CLXDeepLinkRouter.h"
 
 @interface AppDelegate ()
 
@@ -33,6 +34,9 @@
     self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
     self.window.rootViewController = [[AdDemoTabViewController alloc] init];
     [self.window makeKeyAndVisible];
+    
+    // Process automation launch arguments (e.g., -CLXTestFormat banner -CLXTestAction load)
+    [CLXDeepLinkRouter handleLaunchArguments];
     
     return YES;
 }
@@ -63,5 +67,8 @@
     }
 }
 
+- (BOOL)application:(UIApplication *)app openURL:(NSURL *)url options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options {
+    return [CLXDeepLinkRouter handleURL:url];
+}
 
 @end

--- a/demo-app-objc/CloudXObjCRemotePods/CLXDeepLinkRouter.h
+++ b/demo-app-objc/CloudXObjCRemotePods/CLXDeepLinkRouter.h
@@ -1,0 +1,40 @@
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * @brief Routes deep link URLs to the appropriate ad format tab and triggers load/show actions.
+ *
+ * @discussion Handles the `cloudx-demo://` URL scheme. Used by automated test runners
+ * to exercise all ad formats via `xcrun simctl openurl` or `xcrun simctl launch` with arguments.
+ *
+ * Supported routes:
+ *   cloudx-demo://init[?env=production|staging|dev]
+ *   cloudx-demo://test?format=<FORMAT>[&action=load|show]
+ *   cloudx-demo://test-all
+ *
+ * Launch arguments (preferred for automation — avoids iOS URL scheme confirmation dialog):
+ *   -CLXTestFormat <banner|mrec|interstitial|rewarded> [-CLXTestAction <load|show>]
+ *   -CLXTestCommand <init|test-all>
+ */
+@interface CLXDeepLinkRouter : NSObject
+
+/**
+ * @brief Attempts to handle a deep link URL.
+ * @param url The URL to handle.
+ * @return YES if the URL was recognized and handled, NO otherwise.
+ */
++ (BOOL)handleURL:(NSURL *)url;
+
+/**
+ * @brief Checks process launch arguments for test commands and dispatches them.
+ *
+ * @discussion Call from `application:didFinishLaunchingWithOptions:` after the UI is set up.
+ * Reads `-CLXTestFormat`, `-CLXTestAction`, and `-CLXTestCommand` from NSProcessInfo.arguments,
+ * constructs the corresponding deep link URL, and dispatches it after a short delay.
+ */
++ (void)handleLaunchArguments;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/demo-app-objc/CloudXObjCRemotePods/CLXDeepLinkRouter.m
+++ b/demo-app-objc/CloudXObjCRemotePods/CLXDeepLinkRouter.m
@@ -1,0 +1,269 @@
+#import "CLXDeepLinkRouter.h"
+#import "AdDemoTabViewController.h"
+#import "DemoAppLogger.h"
+
+static NSString *const kScheme = @"cloudx-demo";
+
+@implementation CLXDeepLinkRouter
+
++ (void)handleLaunchArguments {
+    NSArray<NSString *> *args = [NSProcessInfo processInfo].arguments;
+
+    NSString *format = nil;
+    NSString *action = nil;
+    NSString *command = nil;
+
+    for (NSUInteger i = 0; i < args.count; i++) {
+        if ([args[i] isEqualToString:@"-CLXTestFormat"] && i + 1 < args.count) {
+            format = args[i + 1];
+        } else if ([args[i] isEqualToString:@"-CLXTestAction"] && i + 1 < args.count) {
+            action = args[i + 1];
+        } else if ([args[i] isEqualToString:@"-CLXTestCommand"] && i + 1 < args.count) {
+            command = args[i + 1];
+        }
+    }
+
+    if (!format && !command) return;
+
+    NSURL *url;
+    if (command) {
+        url = [NSURL URLWithString:[NSString stringWithFormat:@"%@://%@", kScheme, command]];
+    } else {
+        NSString *act = action ?: @"load";
+        url = [NSURL URLWithString:[NSString stringWithFormat:@"%@://test?format=%@&action=%@", kScheme, format, act]];
+    }
+
+    // Delay to ensure the UI hierarchy is fully established
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1.5 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        [self handleURL:url];
+    });
+}
+
++ (BOOL)handleURL:(NSURL *)url {
+    if (![url.scheme isEqualToString:kScheme]) {
+        return NO;
+    }
+
+    [[DemoAppLogger sharedInstance] logMessage:[NSString stringWithFormat:@"Deep link received: %@", url.absoluteString]];
+
+    NSString *host = url.host;
+
+    if ([host isEqualToString:@"init"]) {
+        [self handleInit:url];
+        return YES;
+    }
+
+    if ([host isEqualToString:@"test"]) {
+        [self handleTest:url];
+        return YES;
+    }
+
+    if ([host isEqualToString:@"test-all"]) {
+        [self handleTestAll];
+        return YES;
+    }
+
+    [[DemoAppLogger sharedInstance] logMessage:[NSString stringWithFormat:@"Unrecognized deep link host: %@", host]];
+    return NO;
+}
+
+#pragma mark - Route Handlers
+
++ (void)handleInit:(NSURL *)url {
+    AdDemoTabViewController *tabVC = [self resolveTabViewController];
+    if (!tabVC) return;
+
+    NSString *env = [self queryValueForKey:@"env" inURL:url] ?: @"production";
+    [tabVC selectTabIndex:0];
+
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.5 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        UINavigationController *navVC = (UINavigationController *)tabVC.selectedViewController;
+        UIViewController *initVC = navVC.viewControllers.firstObject;
+        SEL selector = [self initSelectorForEnvironment:env];
+        if ([initVC respondsToSelector:selector]) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Warc-performSelector-leaks"
+            [initVC performSelector:selector];
+#pragma clang diagnostic pop
+        }
+    });
+}
+
++ (void)handleTest:(NSURL *)url {
+    AdDemoTabViewController *tabVC = [self resolveTabViewController];
+    if (!tabVC) return;
+
+    NSString *format = [self queryValueForKey:@"format" inURL:url];
+    NSString *action = [self queryValueForKey:@"action" inURL:url] ?: @"load";
+
+    if (!format) {
+        [[DemoAppLogger sharedInstance] logMessage:@"Deep link missing 'format' parameter"];
+        return;
+    }
+
+    NSInteger tabIndex = [self tabIndexForFormat:format];
+    if (tabIndex < 0) {
+        [[DemoAppLogger sharedInstance] logMessage:[NSString stringWithFormat:@"Unknown format: %@", format]];
+        return;
+    }
+
+    [tabVC selectTabIndex:tabIndex];
+
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.5 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        UINavigationController *navVC = (UINavigationController *)tabVC.selectedViewController;
+        UIViewController *adVC = navVC.viewControllers.firstObject;
+
+        BOOL isLoadShow = [action isEqualToString:@"load-show"];
+        NSString *effectiveAction = isLoadShow ? @"load" : action;
+
+        SEL selector = [self selectorForFormat:format action:effectiveAction];
+        if (selector && [adVC respondsToSelector:selector]) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Warc-performSelector-leaks"
+            [adVC performSelector:selector];
+#pragma clang diagnostic pop
+        } else {
+            [[DemoAppLogger sharedInstance] logMessage:
+                [NSString stringWithFormat:@"VC does not respond to %@ for format=%@, action=%@",
+                    NSStringFromSelector(selector), format, action]];
+            return;
+        }
+
+        if (isLoadShow) {
+            SEL showSel = [self selectorForFormat:format action:@"show"];
+            if (showSel && [adVC respondsToSelector:showSel]) {
+                dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(16.0 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Warc-performSelector-leaks"
+                    [adVC performSelector:showSel];
+#pragma clang diagnostic pop
+                });
+            }
+        }
+    });
+}
+
++ (void)handleTestAll {
+    AdDemoTabViewController *tabVC = [self resolveTabViewController];
+    if (!tabVC) return;
+
+    NSArray<NSDictionary *> *steps = @[
+        @{@"format": @"banner", @"action": @"load"},
+        @{@"format": @"mrec", @"action": @"load"},
+        @{@"format": @"interstitial", @"action": @"load"},
+        @{@"format": @"interstitial", @"action": @"show", @"delay": @16},
+        @{@"format": @"rewarded", @"action": @"load"},
+        @{@"format": @"rewarded", @"action": @"show", @"delay": @16},
+    ];
+
+    [self executeSteps:steps atIndex:0 tabVC:tabVC];
+}
+
++ (void)executeSteps:(NSArray<NSDictionary *> *)steps atIndex:(NSUInteger)index tabVC:(AdDemoTabViewController *)tabVC {
+    if (index >= steps.count) {
+        [[DemoAppLogger sharedInstance] logMessage:@"test-all sequence complete"];
+        return;
+    }
+
+    NSDictionary *step = steps[index];
+    NSString *format = step[@"format"];
+    NSString *action = step[@"action"];
+    NSTimeInterval delay = [step[@"delay"] doubleValue] ?: 1.0;
+
+    NSInteger tabIndex = [self tabIndexForFormat:format];
+    if (tabIndex < 0 || tabIndex >= (NSInteger)tabVC.viewControllers.count) {
+        [self executeSteps:steps atIndex:index + 1 tabVC:tabVC];
+        return;
+    }
+
+    [tabVC selectTabIndex:tabIndex];
+
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.5 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        UINavigationController *navVC = (UINavigationController *)tabVC.selectedViewController;
+        UIViewController *adVC = navVC.viewControllers.firstObject;
+        SEL selector = [self selectorForFormat:format action:action];
+        if (selector && [adVC respondsToSelector:selector]) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Warc-performSelector-leaks"
+            [adVC performSelector:selector];
+#pragma clang diagnostic pop
+        }
+
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delay * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+            [self executeSteps:steps atIndex:index + 1 tabVC:tabVC];
+        });
+    });
+}
+
+#pragma mark - Tab Resolution
+
++ (NSInteger)tabIndexForFormat:(NSString *)format {
+    static NSDictionary<NSString *, NSNumber *> *map;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        map = @{
+            @"banner": @1,
+            @"mrec": @4,
+            @"interstitial": @2,
+            @"rewarded": @3,
+        };
+    });
+    NSNumber *index = map[format];
+    return index ? index.integerValue : -1;
+}
+
++ (SEL)selectorForFormat:(NSString *)format action:(NSString *)action {
+    BOOL isShow = [action isEqualToString:@"show"];
+
+    if ([format isEqualToString:@"banner"]) {
+        return @selector(loadBannerAd);
+    }
+    if ([format isEqualToString:@"mrec"]) {
+        return @selector(loadMRECAd);
+    }
+    if ([format isEqualToString:@"interstitial"]) {
+        return isShow ? @selector(showInterstitialAd) : @selector(loadInterstitialAd);
+    }
+    if ([format isEqualToString:@"rewarded"]) {
+        return isShow ? @selector(showRewardedAd) : @selector(loadRewardedAd);
+    }
+    return nil;
+}
+
++ (SEL)initSelectorForEnvironment:(NSString *)env {
+    if ([env isEqualToString:@"staging"]) return @selector(initializeWithStagingEnvironment);
+    if ([env isEqualToString:@"dev"]) return @selector(initializeWithDevEnvironment);
+    return @selector(initializeWithProductionEnvironment);
+}
+
+#pragma mark - Helpers
+
++ (nullable AdDemoTabViewController *)resolveTabViewController {
+    UIWindow *window = UIApplication.sharedApplication.keyWindow;
+    UIViewController *rootVC = window.rootViewController;
+
+    if ([rootVC isKindOfClass:[AdDemoTabViewController class]]) {
+        return (AdDemoTabViewController *)rootVC;
+    }
+    if ([rootVC isKindOfClass:[UINavigationController class]]) {
+        UIViewController *topVC = ((UINavigationController *)rootVC).topViewController;
+        if ([topVC isKindOfClass:[AdDemoTabViewController class]]) {
+            return (AdDemoTabViewController *)topVC;
+        }
+    }
+
+    [[DemoAppLogger sharedInstance] logMessage:@"Could not resolve AdDemoTabViewController for deep link"];
+    return nil;
+}
+
++ (nullable NSString *)queryValueForKey:(NSString *)key inURL:(NSURL *)url {
+    NSURLComponents *components = [NSURLComponents componentsWithURL:url resolvingAgainstBaseURL:NO];
+    for (NSURLQueryItem *item in components.queryItems) {
+        if ([item.name isEqualToString:key]) {
+            return item.value;
+        }
+    }
+    return nil;
+}
+
+@end

--- a/demo-app-objc/CloudXObjCRemotePods/Info.plist
+++ b/demo-app-objc/CloudXObjCRemotePods/Info.plist
@@ -9,6 +9,17 @@
 		<key>NSAllowsArbitraryLoads</key>
 		<true/>
 	</dict>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>cloudx-demo</string>
+			</array>
+			<key>CFBundleURLName</key>
+			<string>com.cloudx.demo</string>
+		</dict>
+	</array>
 	<key>NSUserTrackingUsageDescription</key>
 	<string>This identifier will be used to deliver personalized ads to you.</string>
 	<key>SKAdNetworkItems</key>

--- a/demo-app-objc/CloudXObjCRemotePods/Views/Ad/AdDemoTabViewController.h
+++ b/demo-app-objc/CloudXObjCRemotePods/Views/Ad/AdDemoTabViewController.h
@@ -4,6 +4,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface AdDemoTabViewController : UITabBarController
 
+/**
+ * @brief Selects the tab at the given index, handling the "More" tab if needed.
+ * @param index The zero-based tab index to select.
+ */
+- (void)selectTabIndex:(NSUInteger)index;
+
 @end
 
 NS_ASSUME_NONNULL_END 

--- a/demo-app-objc/CloudXObjCRemotePods/Views/Ad/AdDemoTabViewController.m
+++ b/demo-app-objc/CloudXObjCRemotePods/Views/Ad/AdDemoTabViewController.m
@@ -47,4 +47,10 @@
     ];
 }
 
+- (void)selectTabIndex:(NSUInteger)index {
+    if (index < self.viewControllers.count) {
+        self.selectedIndex = index;
+    }
+}
+
 @end 

--- a/demo-app-swift/CloudXSwiftRemotePods/AppDelegate.swift
+++ b/demo-app-swift/CloudXSwiftRemotePods/AppDelegate.swift
@@ -31,7 +31,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         self.window?.rootViewController = AdDemoTabViewController()
         self.window?.makeKeyAndVisible()
         
+        // Process automation launch arguments (e.g., -CLXTestFormat banner -CLXTestAction load)
+        DeepLinkRouter.handleLaunchArguments()
+        
         return true
+    }
+    
+    func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
+        return DeepLinkRouter.handleURL(url)
     }
     
     private func requestAppTrackingTransparencyPermission() {

--- a/demo-app-swift/CloudXSwiftRemotePods/DeepLinkRouter.swift
+++ b/demo-app-swift/CloudXSwiftRemotePods/DeepLinkRouter.swift
@@ -1,0 +1,245 @@
+import UIKit
+
+/// Routes `cloudx-demo://` deep link URLs to the appropriate ad format tab and triggers load/show actions.
+///
+/// Used by automated test runners to exercise all ad formats via `xcrun simctl openurl`.
+///
+/// Supported routes:
+/// - `cloudx-demo://init[?env=production|staging|dev]`
+/// - `cloudx-demo://test?format=<FORMAT>[&action=load|show]`
+/// - `cloudx-demo://test-all`
+enum DeepLinkRouter {
+
+    private static let scheme = "cloudx-demo"
+
+    /// Checks process launch arguments for test commands and dispatches them.
+    /// Call from `application(_:didFinishLaunchingWithOptions:)` after the UI is set up.
+    static func handleLaunchArguments() {
+        let args = ProcessInfo.processInfo.arguments
+        var format: String?
+        var action: String?
+        var command: String?
+
+        for i in 0..<args.count {
+            switch args[i] {
+            case "-CLXTestFormat" where i + 1 < args.count:
+                format = args[i + 1]
+            case "-CLXTestAction" where i + 1 < args.count:
+                action = args[i + 1]
+            case "-CLXTestCommand" where i + 1 < args.count:
+                command = args[i + 1]
+            default:
+                break
+            }
+        }
+
+        guard format != nil || command != nil else { return }
+
+        let url: URL
+        if let command = command {
+            url = URL(string: "\(scheme)://\(command)")!
+        } else {
+            let act = action ?? "load"
+            url = URL(string: "\(scheme)://test?format=\(format!)&action=\(act)")!
+        }
+
+        // Delay to ensure the UI hierarchy is fully established
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
+            _ = handleURL(url)
+        }
+    }
+
+    /// Attempts to handle a deep link URL.
+    /// - Returns: `true` if the URL was recognized and handled.
+    static func handleURL(_ url: URL) -> Bool {
+        guard url.scheme == scheme else { return false }
+
+        DemoAppLogger.sharedInstance.logMessage("Deep link received: \(url.absoluteString)")
+
+        guard let host = url.host else { return false }
+
+        switch host {
+        case "init":
+            handleInit(url)
+            return true
+        case "test":
+            handleTest(url)
+            return true
+        case "test-all":
+            handleTestAll()
+            return true
+        default:
+            DemoAppLogger.sharedInstance.logMessage("Unrecognized deep link host: \(host)")
+            return false
+        }
+    }
+
+    // MARK: - Route Handlers
+
+    private static func handleInit(_ url: URL) {
+        guard let tabVC = resolveTabViewController() else { return }
+
+        let env = queryValue(forKey: "env", in: url) ?? "production"
+        tabVC.selectTab(at: 0)
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+            guard let navVC = tabVC.selectedViewController as? UINavigationController,
+                  let initVC = navVC.viewControllers.first else { return }
+
+            let selector = initSelector(for: env)
+            if initVC.responds(to: selector) {
+                initVC.perform(selector)
+            }
+        }
+    }
+
+    private static func handleTest(_ url: URL) {
+        guard let tabVC = resolveTabViewController() else { return }
+
+        guard let format = queryValue(forKey: "format", in: url) else {
+            DemoAppLogger.sharedInstance.logMessage("Deep link missing 'format' parameter")
+            return
+        }
+
+        let action = queryValue(forKey: "action", in: url) ?? "load"
+
+        guard let tabIndex = tabIndex(for: format), tabIndex >= 0 else {
+            DemoAppLogger.sharedInstance.logMessage("Unknown format: \(format)")
+            return
+        }
+
+        tabVC.selectTab(at: tabIndex)
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+            guard let navVC = tabVC.selectedViewController as? UINavigationController,
+                  let adVC = navVC.viewControllers.first else { return }
+
+            let isLoadShow = action == "load-show"
+            let effectiveAction = isLoadShow ? "load" : action
+
+            guard let sel = selector(for: format, action: effectiveAction) else { return }
+            if adVC.responds(to: sel) {
+                adVC.perform(sel)
+            } else {
+                DemoAppLogger.sharedInstance.logMessage(
+                    "VC does not respond to \(NSStringFromSelector(sel)) for format=\(format), action=\(action)")
+                return
+            }
+
+            if isLoadShow, let showSel = selector(for: format, action: "show"), adVC.responds(to: showSel) {
+                DispatchQueue.main.asyncAfter(deadline: .now() + 16.0) {
+                    adVC.perform(showSel)
+                }
+            }
+        }
+    }
+
+    private static func handleTestAll() {
+        guard let tabVC = resolveTabViewController() else { return }
+
+        let steps: [(format: String, action: String, delay: TimeInterval)] = [
+            ("banner", "load", 1),
+            ("mrec", "load", 1),
+            ("interstitial", "load", 16),
+            ("interstitial", "show", 5),
+            ("rewarded", "load", 16),
+            ("rewarded", "show", 5),
+        ]
+
+        executeSteps(steps, at: 0, tabVC: tabVC)
+    }
+
+    private static func executeSteps(_ steps: [(format: String, action: String, delay: TimeInterval)],
+                                     at index: Int,
+                                     tabVC: AdDemoTabViewController) {
+        guard index < steps.count else {
+            DemoAppLogger.sharedInstance.logMessage("test-all sequence complete")
+            return
+        }
+
+        let step = steps[index]
+
+        guard let tabIdx = tabIndex(for: step.format),
+              tabIdx >= 0,
+              tabIdx < tabVC.viewControllers?.count ?? 0 else {
+            executeSteps(steps, at: index + 1, tabVC: tabVC)
+            return
+        }
+
+        tabVC.selectTab(at: tabIdx)
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+            if let navVC = tabVC.selectedViewController as? UINavigationController,
+               let adVC = navVC.viewControllers.first,
+               let sel = selector(for: step.format, action: step.action),
+               adVC.responds(to: sel) {
+                adVC.perform(sel)
+            }
+
+            DispatchQueue.main.asyncAfter(deadline: .now() + step.delay) {
+                executeSteps(steps, at: index + 1, tabVC: tabVC)
+            }
+        }
+    }
+
+    // MARK: - Tab Resolution
+
+    private static func tabIndex(for format: String) -> Int? {
+        let map: [String: Int] = [
+            "banner": 1,
+            "mrec": 4,
+            "interstitial": 2,
+            "rewarded": 3,
+        ]
+        return map[format]
+    }
+
+    private static func selector(for format: String, action: String) -> Selector? {
+        let isShow = action == "show"
+
+        switch format {
+        case "banner":
+            return NSSelectorFromString("loadBannerAd")
+        case "mrec":
+            return NSSelectorFromString("loadMRECAd")
+        case "interstitial":
+            return NSSelectorFromString(isShow ? "showInterstitialAd" : "loadInterstitialAd")
+        case "rewarded":
+            return NSSelectorFromString(isShow ? "showRewardedAd" : "loadRewardedAd")
+        default:
+            return nil
+        }
+    }
+
+    private static func initSelector(for env: String) -> Selector {
+        switch env {
+        case "staging": return NSSelectorFromString("initializeWithStagingEnvironment")
+        case "dev": return NSSelectorFromString("initializeWithDevEnvironment")
+        default: return NSSelectorFromString("initializeWithProductionEnvironment")
+        }
+    }
+
+    // MARK: - Helpers
+
+    private static func resolveTabViewController() -> AdDemoTabViewController? {
+        let window = UIApplication.shared.windows.first(where: { $0.isKeyWindow })
+
+        if let tabVC = window?.rootViewController as? AdDemoTabViewController {
+            return tabVC
+        }
+        if let navVC = window?.rootViewController as? UINavigationController,
+           let tabVC = navVC.topViewController as? AdDemoTabViewController {
+            return tabVC
+        }
+
+        DemoAppLogger.sharedInstance.logMessage("Could not resolve AdDemoTabViewController for deep link")
+        return nil
+    }
+
+    private static func queryValue(forKey key: String, in url: URL) -> String? {
+        URLComponents(url: url, resolvingAgainstBaseURL: false)?
+            .queryItems?
+            .first(where: { $0.name == key })?
+            .value
+    }
+}

--- a/demo-app-swift/CloudXSwiftRemotePods/Info.plist
+++ b/demo-app-swift/CloudXSwiftRemotePods/Info.plist
@@ -9,6 +9,17 @@
 		<key>NSAllowsArbitraryLoads</key>
 		<true/>
 	</dict>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>cloudx-demo</string>
+			</array>
+			<key>CFBundleURLName</key>
+			<string>com.cloudx.demo</string>
+		</dict>
+	</array>
 	<key>SKAdNetworkItems</key>
 	<array>
 		<dict>

--- a/demo-app-swift/CloudXSwiftRemotePods/Views/Ad/AdDemoTabViewController.swift
+++ b/demo-app-swift/CloudXSwiftRemotePods/Views/Ad/AdDemoTabViewController.swift
@@ -1,6 +1,13 @@
 import UIKit
 
 class AdDemoTabViewController: UITabBarController {
+
+    /// Selects the tab at the given index, handling the "More" tab if needed.
+    func selectTab(at index: Int) {
+        if index < (viewControllers?.count ?? 0) {
+            selectedIndex = index
+        }
+    }
     
     override func viewDidLoad() {
         super.viewDidLoad()


### PR DESCRIPTION
## Summary

- Adds `CLXDeepLinkRouter` (ObjC) and `DeepLinkRouter` (Swift) to both public demo apps for programmatic ad format testing via `simctl launch` arguments
- Supports `test-all` (sequential cycle through all formats), individual format `load`/`show`, and combined `load-show` for fullscreen ads
- Public apps exclude rewarded-interstitial format (not available in public SDK)

## Test plan

- [ ] Build and run ObjC demo app on simulator with `-CLXTestCommand test-all`
- [ ] Build and run Swift demo app on simulator with `-CLXTestFormat banner -CLXTestAction load`
- [ ] Verify no URL scheme confirmation dialog (launch args bypass it)


Made with [Cursor](https://cursor.com)