### PR TITLE
Replace alert dialogs with non-blocking dropdown toasts

### DIFF
--- a/demo-app-objc/CloudXObjCRemotePods/Views/Ad/BaseAdViewController.m
+++ b/demo-app-objc/CloudXObjCRemotePods/Views/Ad/BaseAdViewController.m
@@ -47,9 +47,7 @@
 - (void)showAlertWithTitle:(NSString *)title message:(NSString *)message {
     NSString *safeTitle = title ?: @"Alert";
     NSString *safeMessage = message ?: @"";
-    dispatch_async(dispatch_get_main_queue(), ^{
-        [DemoToastView showInViewController:self title:safeTitle message:safeMessage];
-    });
+    [DemoToastView showInViewController:self title:safeTitle message:safeMessage];
 }
 
 - (void)initializeSDKWithCompletion:(void (^)(BOOL success, NSError *error))completion {

--- a/demo-app-objc/CloudXObjCRemotePods/Views/Ad/BaseAdViewController.m
+++ b/demo-app-objc/CloudXObjCRemotePods/Views/Ad/BaseAdViewController.m
@@ -6,6 +6,7 @@
 #import "LogsModalViewController.h"
 #import "DemoAppLogger.h"
 #import "CLXDemoConfigManager.h"
+#import "DemoToastView.h"
 
 @implementation BaseAdViewController
 
@@ -47,17 +48,7 @@
     NSString *safeTitle = title ?: @"Alert";
     NSString *safeMessage = message ?: @"";
     dispatch_async(dispatch_get_main_queue(), ^{
-        UIAlertController *alert = [UIAlertController alertControllerWithTitle:safeTitle
-                                                                     message:safeMessage
-                                                              preferredStyle:UIAlertControllerStyleAlert];
-        
-        UIAlertAction *okAction = [UIAlertAction actionWithTitle:@"OK"
-                                                          style:UIAlertActionStyleDefault
-                                                        handler:^(UIAlertAction * _Nonnull action) {
-            // No action needed
-        }];
-        [alert addAction:okAction];
-        [self presentViewController:alert animated:YES completion:nil];
+        [DemoToastView showInViewController:self title:safeTitle message:safeMessage];
     });
 }
 

--- a/demo-app-objc/CloudXObjCRemotePods/Views/Ad/DemoToastView.h
+++ b/demo-app-objc/CloudXObjCRemotePods/Views/Ad/DemoToastView.h
@@ -1,0 +1,25 @@
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ @brief Non-blocking dropdown toast for surfacing errors and informational messages.
+ @discussion Slides down from the top of the screen, auto-dismisses after a few seconds.
+             Tapping the toast presents a detail popup with the full message.
+             Supports queueing — multiple toasts display sequentially without overlap.
+ */
+@interface DemoToastView : UIView
+
+/**
+ @brief Shows a dropdown toast at the top of the given view controller's view.
+ @param viewController The view controller whose view will host the toast.
+ @param title Bold title text displayed on the toast.
+ @param message Brief description displayed below the title (truncated to 2 lines).
+ */
++ (void)showInViewController:(UIViewController *)viewController
+                       title:(NSString *)title
+                     message:(NSString *)message;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/demo-app-objc/CloudXObjCRemotePods/Views/Ad/DemoToastView.m
+++ b/demo-app-objc/CloudXObjCRemotePods/Views/Ad/DemoToastView.m
@@ -1,0 +1,210 @@
+#import "DemoToastView.h"
+
+static const NSTimeInterval kToastDisplayDuration = 4.0;
+static const NSTimeInterval kToastAnimationDuration = 0.3;
+static const CGFloat kToastHorizontalPadding = 16.0;
+static const CGFloat kToastInternalPadding = 12.0;
+static const CGFloat kToastCornerRadius = 12.0;
+
+@interface DemoToastView ()
+
+@property (nonatomic, strong) UILabel *titleLabel;
+@property (nonatomic, strong) UILabel *messageLabel;
+@property (nonatomic, copy) NSString *fullMessage;
+@property (nonatomic, weak) UIViewController *hostViewController;
+@property (nonatomic, strong) NSLayoutConstraint *topConstraint;
+
+@end
+
+static NSMutableArray<void (^)(void)> *_toastQueue;
+static BOOL _isShowingToast = NO;
+
+@implementation DemoToastView
+
++ (void)initialize {
+    if (self == [DemoToastView class]) {
+        _toastQueue = [NSMutableArray new];
+    }
+}
+
++ (void)showInViewController:(UIViewController *)viewController
+                       title:(NSString *)title
+                     message:(NSString *)message {
+    dispatch_async(dispatch_get_main_queue(), ^{
+        void (^showBlock)(void) = ^{
+            _isShowingToast = YES;
+            [self presentToastInViewController:viewController title:title message:message];
+        };
+
+        if (_isShowingToast) {
+            [_toastQueue addObject:showBlock];
+        } else {
+            showBlock();
+        }
+    });
+}
+
++ (void)presentToastInViewController:(UIViewController *)viewController
+                               title:(NSString *)title
+                             message:(NSString *)message {
+    DemoToastView *toast = [[DemoToastView alloc] initWithTitle:title
+                                                        message:message
+                                             hostViewController:viewController];
+    [viewController.view addSubview:toast];
+
+    toast.translatesAutoresizingMaskIntoConstraints = NO;
+    toast.topConstraint = [toast.topAnchor constraintEqualToAnchor:viewController.view.safeAreaLayoutGuide.topAnchor
+                                                           constant:-120];
+
+    [NSLayoutConstraint activateConstraints:@[
+        toast.topConstraint,
+        [toast.leadingAnchor constraintEqualToAnchor:viewController.view.leadingAnchor constant:kToastHorizontalPadding],
+        [toast.trailingAnchor constraintEqualToAnchor:viewController.view.trailingAnchor constant:-kToastHorizontalPadding]
+    ]];
+
+    [viewController.view layoutIfNeeded];
+
+    toast.topConstraint.constant = 8;
+    [UIView animateWithDuration:kToastAnimationDuration
+                          delay:0
+         usingSpringWithDamping:0.8
+          initialSpringVelocity:0.5
+                        options:UIViewAnimationOptionCurveEaseOut
+                     animations:^{
+        [viewController.view layoutIfNeeded];
+    } completion:^(BOOL finished) {
+        [toast scheduleAutoDismiss];
+    }];
+}
+
+- (instancetype)initWithTitle:(NSString *)title
+                      message:(NSString *)message
+           hostViewController:(UIViewController *)hostVC {
+    self = [super initWithFrame:CGRectZero];
+    if (self) {
+        _fullMessage = message ?: @"";
+        _hostViewController = hostVC;
+        [self setupWithTitle:title ?: @"" message:_fullMessage];
+    }
+    return self;
+}
+
+- (void)setupWithTitle:(NSString *)title message:(NSString *)message {
+    self.backgroundColor = [UIColor colorWithRed:0.15 green:0.15 blue:0.18 alpha:0.95];
+    self.layer.cornerRadius = kToastCornerRadius;
+    self.layer.shadowColor = [UIColor blackColor].CGColor;
+    self.layer.shadowOffset = CGSizeMake(0, 4);
+    self.layer.shadowRadius = 8;
+    self.layer.shadowOpacity = 0.3;
+    self.clipsToBounds = NO;
+
+    UIView *accentBar = [[UIView alloc] init];
+    accentBar.backgroundColor = [UIColor systemOrangeColor];
+    accentBar.layer.cornerRadius = 1.5;
+    accentBar.translatesAutoresizingMaskIntoConstraints = NO;
+    [self addSubview:accentBar];
+
+    self.titleLabel = [[UILabel alloc] init];
+    self.titleLabel.text = title;
+    self.titleLabel.font = [UIFont systemFontOfSize:14 weight:UIFontWeightSemibold];
+    self.titleLabel.textColor = [UIColor whiteColor];
+    self.titleLabel.numberOfLines = 1;
+    self.titleLabel.translatesAutoresizingMaskIntoConstraints = NO;
+    [self addSubview:self.titleLabel];
+
+    self.messageLabel = [[UILabel alloc] init];
+    self.messageLabel.text = message;
+    self.messageLabel.font = [UIFont systemFontOfSize:12 weight:UIFontWeightRegular];
+    self.messageLabel.textColor = [UIColor colorWithWhite:0.85 alpha:1.0];
+    self.messageLabel.numberOfLines = 2;
+    self.messageLabel.lineBreakMode = NSLineBreakByTruncatingTail;
+    self.messageLabel.translatesAutoresizingMaskIntoConstraints = NO;
+    [self addSubview:self.messageLabel];
+
+    UILabel *tapHint = [[UILabel alloc] init];
+    tapHint.text = @"Tap for details";
+    tapHint.font = [UIFont systemFontOfSize:10 weight:UIFontWeightMedium];
+    tapHint.textColor = [UIColor colorWithWhite:0.6 alpha:1.0];
+    tapHint.translatesAutoresizingMaskIntoConstraints = NO;
+    [self addSubview:tapHint];
+
+    [NSLayoutConstraint activateConstraints:@[
+        [accentBar.leadingAnchor constraintEqualToAnchor:self.leadingAnchor constant:kToastInternalPadding],
+        [accentBar.topAnchor constraintEqualToAnchor:self.topAnchor constant:kToastInternalPadding],
+        [accentBar.bottomAnchor constraintEqualToAnchor:self.bottomAnchor constant:-kToastInternalPadding],
+        [accentBar.widthAnchor constraintEqualToConstant:3],
+
+        [self.titleLabel.leadingAnchor constraintEqualToAnchor:accentBar.trailingAnchor constant:10],
+        [self.titleLabel.trailingAnchor constraintEqualToAnchor:tapHint.leadingAnchor constant:-8],
+        [self.titleLabel.topAnchor constraintEqualToAnchor:self.topAnchor constant:kToastInternalPadding],
+
+        [self.messageLabel.leadingAnchor constraintEqualToAnchor:self.titleLabel.leadingAnchor],
+        [self.messageLabel.trailingAnchor constraintEqualToAnchor:self.trailingAnchor constant:-kToastInternalPadding],
+        [self.messageLabel.topAnchor constraintEqualToAnchor:self.titleLabel.bottomAnchor constant:4],
+        [self.messageLabel.bottomAnchor constraintEqualToAnchor:self.bottomAnchor constant:-kToastInternalPadding],
+
+        [tapHint.trailingAnchor constraintEqualToAnchor:self.trailingAnchor constant:-kToastInternalPadding],
+        [tapHint.centerYAnchor constraintEqualToAnchor:self.titleLabel.centerYAnchor]
+    ]];
+
+    UITapGestureRecognizer *tap = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(toastTapped)];
+    [self addGestureRecognizer:tap];
+
+    UISwipeGestureRecognizer *swipeUp = [[UISwipeGestureRecognizer alloc] initWithTarget:self action:@selector(dismissAnimated)];
+    swipeUp.direction = UISwipeGestureRecognizerDirectionUp;
+    [self addGestureRecognizer:swipeUp];
+}
+
+- (void)scheduleAutoDismiss {
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(kToastDisplayDuration * NSEC_PER_SEC)),
+                   dispatch_get_main_queue(), ^{
+        if (self.superview) {
+            [self dismissAnimated];
+        }
+    });
+}
+
+- (void)toastTapped {
+    UIViewController *host = self.hostViewController;
+    NSString *msg = self.fullMessage;
+    NSString *title = self.titleLabel.text;
+
+    [self dismissAnimatedWithCompletion:^{
+        if (!host) return;
+        UIAlertController *detail = [UIAlertController alertControllerWithTitle:title
+                                                                       message:msg
+                                                                preferredStyle:UIAlertControllerStyleAlert];
+        [detail addAction:[UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleDefault handler:nil]];
+        [host presentViewController:detail animated:YES completion:nil];
+    }];
+}
+
+- (void)dismissAnimated {
+    [self dismissAnimatedWithCompletion:nil];
+}
+
+- (void)dismissAnimatedWithCompletion:(void (^ _Nullable)(void))completion {
+    self.topConstraint.constant = -120;
+    [UIView animateWithDuration:kToastAnimationDuration
+                          delay:0
+                        options:UIViewAnimationOptionCurveEaseIn
+                     animations:^{
+        [self.superview layoutIfNeeded];
+        self.alpha = 0;
+    } completion:^(BOOL finished) {
+        [self removeFromSuperview];
+        if (completion) completion();
+        [DemoToastView dequeueNext];
+    }];
+}
+
++ (void)dequeueNext {
+    _isShowingToast = NO;
+    if (_toastQueue.count > 0) {
+        void (^next)(void) = _toastQueue.firstObject;
+        [_toastQueue removeObjectAtIndex:0];
+        next();
+    }
+}
+
+@end

--- a/demo-app-objc/CloudXObjCRemotePods/Views/Ad/DemoToastView.m
+++ b/demo-app-objc/CloudXObjCRemotePods/Views/Ad/DemoToastView.m
@@ -65,7 +65,7 @@ static BOOL _isDismissing = NO;
 
     [viewController.view layoutIfNeeded];
 
-    toast.topConstraint.constant = 8;
+    toast.topConstraint.constant = 0;
     [UIView animateWithDuration:kToastAnimationDuration
                           delay:0
          usingSpringWithDamping:0.8

--- a/demo-app-objc/CloudXObjCRemotePods/Views/Ad/DemoToastView.m
+++ b/demo-app-objc/CloudXObjCRemotePods/Views/Ad/DemoToastView.m
@@ -18,6 +18,7 @@ static const CGFloat kToastCornerRadius = 12.0;
 
 static NSMutableArray<void (^)(void)> *_toastQueue;
 static BOOL _isShowingToast = NO;
+static BOOL _isDismissing = NO;
 
 @implementation DemoToastView
 
@@ -158,13 +159,15 @@ static BOOL _isShowingToast = NO;
 - (void)scheduleAutoDismiss {
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(kToastDisplayDuration * NSEC_PER_SEC)),
                    dispatch_get_main_queue(), ^{
-        if (self.superview) {
+        if (self.superview && !_isDismissing) {
             [self dismissAnimated];
         }
     });
 }
 
 - (void)toastTapped {
+    if (_isDismissing) return;
+
     UIViewController *host = self.hostViewController;
     NSString *msg = self.fullMessage;
     NSString *title = self.titleLabel.text;
@@ -184,6 +187,9 @@ static BOOL _isShowingToast = NO;
 }
 
 - (void)dismissAnimatedWithCompletion:(void (^ _Nullable)(void))completion {
+    if (_isDismissing) return;
+    _isDismissing = YES;
+
     self.topConstraint.constant = -120;
     [UIView animateWithDuration:kToastAnimationDuration
                           delay:0
@@ -192,6 +198,7 @@ static BOOL _isShowingToast = NO;
         [self.superview layoutIfNeeded];
         self.alpha = 0;
     } completion:^(BOOL finished) {
+        _isDismissing = NO;
         [self removeFromSuperview];
         if (completion) completion();
         [DemoToastView dequeueNext];

--- a/demo-app-objc/CloudXObjCRemotePods/Views/Ad/KeyValueDemoViewController.m
+++ b/demo-app-objc/CloudXObjCRemotePods/Views/Ad/KeyValueDemoViewController.m
@@ -9,6 +9,7 @@
 #import <CloudXCore/CloudXCore.h>
 #import <CloudXCore/CLXKeyValueState.h>
 #import "DemoAppLogger.h"
+#import "DemoToastView.h"
 
 @interface KeyValueDemoViewController () <UITableViewDelegate, UITableViewDataSource>
 
@@ -518,14 +519,10 @@
     NSArray *sortedKeys = [[kvDict allKeys] sortedArrayUsingSelector:@selector(compare:)];
     NSString *key = sortedKeys[indexPath.row];
     NSString *value = kvDict[key];
-    
-    UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"Key-Value Details" 
-                                                                   message:[NSString stringWithFormat:@"Key: %@\nValue: %@\n\nType: %@", 
-                                                                           key, value,
-                                                                           indexPath.section == 0 ? @"User-Level" : @"App-Level"]
-                                                            preferredStyle:UIAlertControllerStyleAlert];
-    [alert addAction:[UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleDefault handler:nil]];
-    [self presentViewController:alert animated:YES completion:nil];
+    NSString *detail = [NSString stringWithFormat:@"Key: %@\nValue: %@\n\nType: %@",
+                        key, value,
+                        indexPath.section == 0 ? @"User-Level" : @"App-Level"];
+    [DemoToastView showInViewController:self title:@"Key-Value Details" message:detail];
 }
 
 - (BOOL)tableView:(UITableView *)tableView canEditRowAtIndexPath:(NSIndexPath *)indexPath {
@@ -560,11 +557,7 @@
 #pragma mark - Helpers
 
 - (void)showAlert:(NSString *)title message:(NSString *)message {
-    UIAlertController *alert = [UIAlertController alertControllerWithTitle:title 
-                                                                   message:message 
-                                                            preferredStyle:UIAlertControllerStyleAlert];
-    [alert addAction:[UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleDefault handler:nil]];
-    [self presentViewController:alert animated:YES completion:nil];
+    [DemoToastView showInViewController:self title:title message:message];
 }
 
 @end

--- a/demo-app-swift/CloudXSwiftRemotePods/Views/Ad/BaseAdViewController.swift
+++ b/demo-app-swift/CloudXSwiftRemotePods/Views/Ad/BaseAdViewController.swift
@@ -89,9 +89,7 @@ class BaseAdViewController: UIViewController, AdStateManaging {
     private static var lastAdFormat: String?
     
     func showAlert(title: String, message: String) {
-        DispatchQueue.main.async {
-            DemoToastView.show(in: self, title: title, message: message)
-        }
+        DemoToastView.show(in: self, title: title, message: message)
     }
     
     func initializeSDK() async {

--- a/demo-app-swift/CloudXSwiftRemotePods/Views/Ad/BaseAdViewController.swift
+++ b/demo-app-swift/CloudXSwiftRemotePods/Views/Ad/BaseAdViewController.swift
@@ -90,9 +90,7 @@ class BaseAdViewController: UIViewController, AdStateManaging {
     
     func showAlert(title: String, message: String) {
         DispatchQueue.main.async {
-            let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
-            alert.addAction(.init(title: "OK", style: .default))
-            self.present(alert, animated: true)
+            DemoToastView.show(in: self, title: title, message: message)
         }
     }
     

--- a/demo-app-swift/CloudXSwiftRemotePods/Views/Ad/DemoToastView.swift
+++ b/demo-app-swift/CloudXSwiftRemotePods/Views/Ad/DemoToastView.swift
@@ -62,7 +62,7 @@ final class DemoToastView: UIView {
 
         viewController.view.layoutIfNeeded()
 
-        top.constant = 8
+        top.constant = 0
         UIView.animate(
             withDuration: animationDuration,
             delay: 0,
@@ -146,7 +146,7 @@ final class DemoToastView: UIView {
 
         addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(toastTapped)))
 
-        let swipeUp = UISwipeGestureRecognizer(target: self, action: #selector(dismissAnimated))
+        let swipeUp = UISwipeGestureRecognizer(target: self, action: #selector(dismissAnimated as () -> Void))
         swipeUp.direction = .up
         addGestureRecognizer(swipeUp)
     }

--- a/demo-app-swift/CloudXSwiftRemotePods/Views/Ad/DemoToastView.swift
+++ b/demo-app-swift/CloudXSwiftRemotePods/Views/Ad/DemoToastView.swift
@@ -1,0 +1,203 @@
+import UIKit
+
+/// Non-blocking dropdown toast for surfacing errors and informational messages.
+/// Slides down from the top of the screen, auto-dismisses after a few seconds.
+/// Tapping the toast presents a detail popup with the full message.
+/// Supports queueing — multiple toasts display sequentially without overlap.
+final class DemoToastView: UIView {
+
+    private static var toastQueue: [() -> Void] = []
+    private static var isShowingToast = false
+
+    private let titleLabel = UILabel()
+    private let messageLabel = UILabel()
+    private let fullMessage: String
+    private weak var hostViewController: UIViewController?
+    private var topConstraint: NSLayoutConstraint?
+
+    private static let displayDuration: TimeInterval = 4.0
+    private static let animationDuration: TimeInterval = 0.3
+    private static let horizontalPadding: CGFloat = 16
+    private static let internalPadding: CGFloat = 12
+    private static let cornerRadiusValue: CGFloat = 12
+
+    // MARK: - Public API
+
+    static func show(in viewController: UIViewController, title: String, message: String) {
+        DispatchQueue.main.async {
+            let showBlock = {
+                isShowingToast = true
+                presentToast(in: viewController, title: title, message: message)
+            }
+
+            if isShowingToast {
+                toastQueue.append(showBlock)
+            } else {
+                showBlock()
+            }
+        }
+    }
+
+    // MARK: - Presentation
+
+    private static func presentToast(in viewController: UIViewController,
+                                     title: String,
+                                     message: String) {
+        let toast = DemoToastView(title: title, message: message, host: viewController)
+        viewController.view.addSubview(toast)
+
+        toast.translatesAutoresizingMaskIntoConstraints = false
+        let top = toast.topAnchor.constraint(
+            equalTo: viewController.view.safeAreaLayoutGuide.topAnchor,
+            constant: -120
+        )
+        toast.topConstraint = top
+
+        NSLayoutConstraint.activate([
+            top,
+            toast.leadingAnchor.constraint(equalTo: viewController.view.leadingAnchor, constant: horizontalPadding),
+            toast.trailingAnchor.constraint(equalTo: viewController.view.trailingAnchor, constant: -horizontalPadding)
+        ])
+
+        viewController.view.layoutIfNeeded()
+
+        top.constant = 8
+        UIView.animate(
+            withDuration: animationDuration,
+            delay: 0,
+            usingSpringWithDamping: 0.8,
+            initialSpringVelocity: 0.5,
+            options: .curveEaseOut,
+            animations: { viewController.view.layoutIfNeeded() },
+            completion: { _ in toast.scheduleAutoDismiss() }
+        )
+    }
+
+    // MARK: - Init
+
+    private init(title: String, message: String, host: UIViewController) {
+        self.fullMessage = message
+        self.hostViewController = host
+        super.init(frame: .zero)
+        setupUI(title: title, message: message)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError() }
+
+    // MARK: - UI Setup
+
+    private func setupUI(title: String, message: String) {
+        backgroundColor = UIColor(red: 0.15, green: 0.15, blue: 0.18, alpha: 0.95)
+        layer.cornerRadius = Self.cornerRadiusValue
+        layer.shadowColor = UIColor.black.cgColor
+        layer.shadowOffset = CGSize(width: 0, height: 4)
+        layer.shadowRadius = 8
+        layer.shadowOpacity = 0.3
+        clipsToBounds = false
+
+        let accentBar = UIView()
+        accentBar.backgroundColor = .systemOrange
+        accentBar.layer.cornerRadius = 1.5
+        accentBar.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(accentBar)
+
+        titleLabel.text = title
+        titleLabel.font = .systemFont(ofSize: 14, weight: .semibold)
+        titleLabel.textColor = .white
+        titleLabel.numberOfLines = 1
+        titleLabel.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(titleLabel)
+
+        messageLabel.text = message
+        messageLabel.font = .systemFont(ofSize: 12, weight: .regular)
+        messageLabel.textColor = UIColor(white: 0.85, alpha: 1)
+        messageLabel.numberOfLines = 2
+        messageLabel.lineBreakMode = .byTruncatingTail
+        messageLabel.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(messageLabel)
+
+        let tapHint = UILabel()
+        tapHint.text = "Tap for details"
+        tapHint.font = .systemFont(ofSize: 10, weight: .medium)
+        tapHint.textColor = UIColor(white: 0.6, alpha: 1)
+        tapHint.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(tapHint)
+
+        NSLayoutConstraint.activate([
+            accentBar.leadingAnchor.constraint(equalTo: leadingAnchor, constant: Self.internalPadding),
+            accentBar.topAnchor.constraint(equalTo: topAnchor, constant: Self.internalPadding),
+            accentBar.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -Self.internalPadding),
+            accentBar.widthAnchor.constraint(equalToConstant: 3),
+
+            titleLabel.leadingAnchor.constraint(equalTo: accentBar.trailingAnchor, constant: 10),
+            titleLabel.trailingAnchor.constraint(equalTo: tapHint.leadingAnchor, constant: -8),
+            titleLabel.topAnchor.constraint(equalTo: topAnchor, constant: Self.internalPadding),
+
+            messageLabel.leadingAnchor.constraint(equalTo: titleLabel.leadingAnchor),
+            messageLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -Self.internalPadding),
+            messageLabel.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 4),
+            messageLabel.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -Self.internalPadding),
+
+            tapHint.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -Self.internalPadding),
+            tapHint.centerYAnchor.constraint(equalTo: titleLabel.centerYAnchor)
+        ])
+
+        addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(toastTapped)))
+
+        let swipeUp = UISwipeGestureRecognizer(target: self, action: #selector(dismissAnimated))
+        swipeUp.direction = .up
+        addGestureRecognizer(swipeUp)
+    }
+
+    // MARK: - Dismiss
+
+    private func scheduleAutoDismiss() {
+        DispatchQueue.main.asyncAfter(deadline: .now() + Self.displayDuration) { [weak self] in
+            guard let self, self.superview != nil else { return }
+            self.dismissAnimated()
+        }
+    }
+
+    @objc private func toastTapped() {
+        let host = hostViewController
+        let msg = fullMessage
+        let title = titleLabel.text ?? ""
+
+        dismissAnimated { [weak host] in
+            guard let host else { return }
+            let detail = UIAlertController(title: title, message: msg, preferredStyle: .alert)
+            detail.addAction(.init(title: "OK", style: .default))
+            host.present(detail, animated: true)
+        }
+    }
+
+    @objc private func dismissAnimated() {
+        dismissAnimated(completion: nil)
+    }
+
+    private func dismissAnimated(completion: (() -> Void)?) {
+        topConstraint?.constant = -120
+        UIView.animate(
+            withDuration: Self.animationDuration,
+            delay: 0,
+            options: .curveEaseIn,
+            animations: {
+                self.superview?.layoutIfNeeded()
+                self.alpha = 0
+            },
+            completion: { _ in
+                self.removeFromSuperview()
+                completion?()
+                Self.dequeueNext()
+            }
+        )
+    }
+
+    private static func dequeueNext() {
+        isShowingToast = false
+        guard !toastQueue.isEmpty else { return }
+        let next = toastQueue.removeFirst()
+        next()
+    }
+}

--- a/demo-app-swift/CloudXSwiftRemotePods/Views/Ad/DemoToastView.swift
+++ b/demo-app-swift/CloudXSwiftRemotePods/Views/Ad/DemoToastView.swift
@@ -8,6 +8,7 @@ final class DemoToastView: UIView {
 
     private static var toastQueue: [() -> Void] = []
     private static var isShowingToast = false
+    private static var isDismissing = false
 
     private let titleLabel = UILabel()
     private let messageLabel = UILabel()
@@ -154,12 +155,14 @@ final class DemoToastView: UIView {
 
     private func scheduleAutoDismiss() {
         DispatchQueue.main.asyncAfter(deadline: .now() + Self.displayDuration) { [weak self] in
-            guard let self, self.superview != nil else { return }
+            guard let self, self.superview != nil, !Self.isDismissing else { return }
             self.dismissAnimated()
         }
     }
 
     @objc private func toastTapped() {
+        guard !Self.isDismissing else { return }
+
         let host = hostViewController
         let msg = fullMessage
         let title = titleLabel.text ?? ""
@@ -177,6 +180,9 @@ final class DemoToastView: UIView {
     }
 
     private func dismissAnimated(completion: (() -> Void)?) {
+        guard !Self.isDismissing else { return }
+        Self.isDismissing = true
+
         topConstraint?.constant = -120
         UIView.animate(
             withDuration: Self.animationDuration,
@@ -187,6 +193,7 @@ final class DemoToastView: UIView {
                 self.alpha = 0
             },
             completion: { _ in
+                Self.isDismissing = false
                 self.removeFromSuperview()
                 completion?()
                 Self.dequeueNext()

--- a/demo-app-swift/CloudXSwiftRemotePods/Views/Ad/KeyValueDemoViewController.swift
+++ b/demo-app-swift/CloudXSwiftRemotePods/Views/Ad/KeyValueDemoViewController.swift
@@ -510,11 +510,11 @@ class KeyValueDemoViewController: UIViewController, UITableViewDelegate, UITable
         let key = sortedKeys[indexPath.row]
         let value = kvDict[key] ?? ""
         
-        let alert = UIAlertController(title: "Key-Value Details",
-                                     message: "Key: \(key)\nValue: \(value)\n\nType: \(indexPath.section == 0 ? "User-Level" : "App-Level")",
-                                     preferredStyle: .alert)
-        alert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
-        present(alert, animated: true, completion: nil)
+        DemoToastView.show(
+            in: self,
+            title: "Key-Value Details",
+            message: "Key: \(key)\nValue: \(value)\n\nType: \(indexPath.section == 0 ? "User-Level" : "App-Level")"
+        )
     }
     
     func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
@@ -560,9 +560,7 @@ class KeyValueDemoViewController: UIViewController, UITableViewDelegate, UITable
     // MARK: - Helpers
     
     private func showAlert(title: String, message: String) {
-        let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
-        alert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
-        present(alert, animated: true, completion: nil)
+        DemoToastView.show(in: self, title: title, message: message)
     }
 }
 


### PR DESCRIPTION
## Summary

- **DemoToastView** (ObjC + Swift): New dropdown toast component that slides from the top, auto-dismisses after 4s, tap for full detail, supports queueing.
- **BaseAdViewController**: `showAlertWithTitle:message:` / `showAlert(title:message:)` now shows a toast instead of a modal UIAlertController.
- **KeyValueDemoViewController**: Local `showAlert` helper and row detail alert converted to toast. "Clear All?" stays as UIAlertController.

Mirrors the private repo toast refactor for both public demo apps.

## Test plan

- [ ] Build ObjC demo app — verify compilation
- [ ] Build Swift demo app — verify compilation
- [ ] Trigger ad load failure — verify toast appears, auto-dismisses
- [ ] Tap toast — verify detail popup


Made with [Cursor](https://cursor.com)