### PR TITLE
Remove rewarded-interstitial from public demo apps

### DIFF
--- a/demo-app-objc/CloudXObjCRemotePods/CLXDeepLinkRouter.m
+++ b/demo-app-objc/CloudXObjCRemotePods/CLXDeepLinkRouter.m
@@ -17,7 +17,6 @@ static NSDictionary<NSString *, NSString *> *classNameMap(void) {
             @"mrec":                   @"MRECViewController",
             @"interstitial":           @"InterstitialViewController",
             @"rewarded":               @"RewardedViewController",
-            @"rewarded-interstitial":  @"RewardedInterstitialViewController",
         };
     });
     return map;
@@ -53,13 +52,12 @@ static NSDictionary<NSString *, NSString *> *classNameMap(void) {
 #pragma mark - Format Configuration
 
 - (NSArray<NSString *> *)supportedFormats {
-    return @[@"banner", @"mrec", @"interstitial", @"rewarded", @"rewarded-interstitial"];
+    return @[@"banner", @"mrec", @"interstitial", @"rewarded"];
 }
 
 - (BOOL)isFullscreenFormat:(NSString *)format {
     return [format isEqualToString:@"interstitial"] ||
-           [format isEqualToString:@"rewarded"] ||
-           [format isEqualToString:@"rewarded-interstitial"];
+           [format isEqualToString:@"rewarded"];
 }
 
 - (nullable SEL)loadSelectorForFormat:(NSString *)format {
@@ -67,14 +65,12 @@ static NSDictionary<NSString *, NSString *> *classNameMap(void) {
     if ([format isEqualToString:@"mrec"])                  return @selector(loadMRECAd);
     if ([format isEqualToString:@"interstitial"])           return @selector(loadInterstitialAd);
     if ([format isEqualToString:@"rewarded"])               return @selector(loadRewardedAd);
-    if ([format isEqualToString:@"rewarded-interstitial"])  return @selector(loadRewardedInterstitialAd);
     return nil;
 }
 
 - (nullable SEL)showSelectorForFormat:(NSString *)format {
     if ([format isEqualToString:@"interstitial"])           return @selector(showInterstitialAd);
     if ([format isEqualToString:@"rewarded"])               return @selector(showRewardedAd);
-    if ([format isEqualToString:@"rewarded-interstitial"])  return @selector(showRewardedInterstitialAd);
     return nil;
 }
 

--- a/demo-app-swift/CloudXSwiftRemotePods/DeepLinkRouter.swift
+++ b/demo-app-swift/CloudXSwiftRemotePods/DeepLinkRouter.swift
@@ -16,7 +16,6 @@ enum DeepLinkRouter {
         "mrec":                  "MRECViewController",
         "interstitial":          "InterstitialViewController",
         "rewarded":              "RewardedViewController",
-        "rewarded-interstitial": "RewardedInterstitialViewController",
     ]
 
     /// Register the adapter and forward launch arguments.
@@ -60,11 +59,11 @@ private final class Adapter: NSObject, CLXTestHarnessApp {
     // MARK: - Format Configuration
 
     func supportedFormats() -> [String] {
-        ["banner", "mrec", "interstitial", "rewarded", "rewarded-interstitial"]
+        ["banner", "mrec", "interstitial", "rewarded"]
     }
 
     func isFullscreenFormat(_ format: String) -> Bool {
-        format == "interstitial" || format == "rewarded" || format == "rewarded-interstitial"
+        format == "interstitial" || format == "rewarded"
     }
 
     func loadSelector(forFormat format: String) -> Selector? {
@@ -73,7 +72,6 @@ private final class Adapter: NSObject, CLXTestHarnessApp {
         case "mrec":                  return NSSelectorFromString("loadMRECAd")
         case "interstitial":          return NSSelectorFromString("loadInterstitialAd")
         case "rewarded":              return NSSelectorFromString("loadRewardedAd")
-        case "rewarded-interstitial": return NSSelectorFromString("loadRewardedInterstitialAd")
         default:                      return nil
         }
     }
@@ -82,7 +80,6 @@ private final class Adapter: NSObject, CLXTestHarnessApp {
         switch format {
         case "interstitial":          return NSSelectorFromString("showInterstitialAd")
         case "rewarded":              return NSSelectorFromString("showRewardedAd")
-        case "rewarded-interstitial": return NSSelectorFromString("showRewardedInterstitialAd")
         default:                      return nil
         }
     }


### PR DESCRIPTION
## Summary

Remove `rewarded-interstitial` from both public demo app deep link routers. The public apps don't have a `RewardedInterstitialViewController` (that's private-only), but the routers still listed it in their format maps, `supportedFormats`, and selector lookups. This caused the test harness to attempt testing a nonexistent format.

## Changes

- **ObjC** (`CLXDeepLinkRouter.m`): Removed from classNameMap, supportedFormats, isFullscreenFormat, loadSelector, showSelector
- **Swift** (`DeepLinkRouter.swift`): Same five removals

## Test plan

- [ ] Both demo apps build on simulator
- [ ] Test harness `test-all` no longer attempts rewarded-interstitial


Made with [Cursor](https://cursor.com)