### PR TITLE
Consolidate 2.2.5 changelog into 2.2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,20 +15,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.2.6] - 2026-03-30
 
-### Fixed
-- **Vungle Rewarded Crash Fix** — Fixed a crash when checking ad readiness for Vungle rewarded ads
-- **Banner Visibility Accuracy** — Fixed an issue where setting `banner.hidden = YES` did not pause ad refresh. Hidden banners could continue loading ads without being impression-eligible, potentially impacting CPMs.
-- **Improved Dependency Compatibility** — Widened third-party SDK version constraints (VungleAds, FBAudienceNetwork, InMobiSDK) to prevent CocoaPods dependency conflicts when integrating alongside other mediation SDKs
-
----
-
-## [2.2.5] - 2026-03-27
-
 ### Added
 - **Privacy Consent for Unity Ads** — Unity Ads adapter now supports GDPR and CCPA privacy consent forwarding
 - **`isAdReady` Support** — Fullscreen ad adapters now support `isAdReady` for reliably querying ad availability before calling show
 
 ### Fixed
+- **Banner Visibility Accuracy** — Fixed an issue where setting `banner.hidden = YES` did not pause ad refresh. Hidden banners could continue loading ads without being impression-eligible, potentially impacting CPMs.
+- **Improved Dependency Compatibility** — Widened third-party SDK version constraints (VungleAds, FBAudienceNetwork, InMobiSDK) to prevent CocoaPods dependency conflicts when integrating alongside other mediation SDKs
 - **Fullscreen Ad Reliability** — Fixed an issue where ad lifecycle callbacks could be silently lost in rare scenarios
 - **iOS 16 Crash Fix** — Fixed a crash on iOS 16 devices related to session tracking
 


### PR DESCRIPTION
## Summary

- Merges all 2.2.5 changelog entries into the 2.2.6 section
- 2.2.5 has been removed from CocoaPods trunk due to a Vungle rewarded crash bug
- GitHub release and git tag for v2.2.5 have also been deleted

## Test plan

- [x] Changelog formatting is correct
- [x] No 2.2.5 section remains

Made with [Cursor](https://cursor.com)