### PR TITLE
Add deferred banner load/show flow to demo apps

### DIFF
--- a/demo-app-objc/CloudXObjCRemotePods/CLXDeepLinkRouter.m
+++ b/demo-app-objc/CloudXObjCRemotePods/CLXDeepLinkRouter.m
@@ -14,6 +14,7 @@ static NSDictionary<NSString *, NSString *> *classNameMap(void) {
     dispatch_once(&onceToken, ^{
         map = @{
             @"banner":                 @"BannerViewController",
+            @"banner_deferred":        @"BannerViewController",
             @"mrec":                   @"MRECViewController",
             @"interstitial":           @"InterstitialViewController",
             @"rewarded":               @"RewardedViewController",
@@ -52,7 +53,7 @@ static NSDictionary<NSString *, NSString *> *classNameMap(void) {
 #pragma mark - Format Configuration
 
 - (NSArray<NSString *> *)supportedFormats {
-    return @[@"banner", @"mrec", @"interstitial", @"rewarded"];
+    return @[@"banner", @"banner_deferred", @"mrec", @"interstitial", @"rewarded"];
 }
 
 - (BOOL)isFullscreenFormat:(NSString *)format {
@@ -62,6 +63,7 @@ static NSDictionary<NSString *, NSString *> *classNameMap(void) {
 
 - (nullable SEL)loadSelectorForFormat:(NSString *)format {
     if ([format isEqualToString:@"banner"])                return @selector(loadBannerAd);
+    if ([format isEqualToString:@"banner_deferred"])       return @selector(loadBannerDeferred);
     if ([format isEqualToString:@"mrec"])                  return @selector(loadMRECAd);
     if ([format isEqualToString:@"interstitial"])           return @selector(loadInterstitialAd);
     if ([format isEqualToString:@"rewarded"])               return @selector(loadRewardedAd);
@@ -69,6 +71,7 @@ static NSDictionary<NSString *, NSString *> *classNameMap(void) {
 }
 
 - (nullable SEL)showSelectorForFormat:(NSString *)format {
+    if ([format isEqualToString:@"banner_deferred"])       return @selector(showDeferredBanner);
     if ([format isEqualToString:@"interstitial"])           return @selector(showInterstitialAd);
     if ([format isEqualToString:@"rewarded"])               return @selector(showRewardedAd);
     return nil;

--- a/demo-app-objc/CloudXObjCRemotePods/Views/Ad/BannerViewController.m
+++ b/demo-app-objc/CloudXObjCRemotePods/Views/Ad/BannerViewController.m
@@ -7,10 +7,13 @@
 
 @interface BannerViewController ()
 @property (nonatomic, strong) CLXBannerAdView *bannerAd;
+@property (nonatomic, strong) CLXBannerAdView *deferredBannerAd;
 @property (nonatomic, assign) BOOL isSDKInitialized;
 @property (nonatomic, assign) AdState adState;
 @property (nonatomic, strong) UIButton *autoRefreshButton;
+@property (nonatomic, strong) UIButton *loadDeferredButton;
 @property (nonatomic, assign) BOOL autoRefreshEnabled;
+@property (nonatomic, assign) BOOL isDeferredLoad;
 @property (nonatomic, strong) UserDefaultsSettings *settings;
 @end
 
@@ -77,6 +80,17 @@
     loadButton.translatesAutoresizingMaskIntoConstraints = NO;
     [buttonStack addArrangedSubview:loadButton];
     
+    // Load (Deferred) button — loads without adding to hierarchy
+    self.loadDeferredButton = [UIButton buttonWithType:UIButtonTypeSystem];
+    [self.loadDeferredButton setTitle:@"Load (Deferred)" forState:UIControlStateNormal];
+    [self.loadDeferredButton addTarget:self action:@selector(loadBannerDeferred) forControlEvents:UIControlEventTouchUpInside];
+    self.loadDeferredButton.backgroundColor = [UIColor systemBlueColor];
+    [self.loadDeferredButton setTitleColor:[UIColor whiteColor] forState:UIControlStateNormal];
+    self.loadDeferredButton.titleLabel.font = [UIFont boldSystemFontOfSize:16];
+    self.loadDeferredButton.layer.cornerRadius = 8;
+    self.loadDeferredButton.translatesAutoresizingMaskIntoConstraints = NO;
+    [buttonStack addArrangedSubview:self.loadDeferredButton];
+    
     // Auto-refresh toggle button
     self.autoRefreshButton = [UIButton buttonWithType:UIButtonTypeSystem];
     [self.autoRefreshButton setTitle:@"Stop Auto-Refresh" forState:UIControlStateNormal];
@@ -95,6 +109,8 @@
         [buttonStack.topAnchor constraintEqualToAnchor:self.view.safeAreaLayoutGuide.topAnchor constant:100],
         [loadButton.widthAnchor constraintEqualToConstant:200],
         [loadButton.heightAnchor constraintEqualToConstant:44],
+        [self.loadDeferredButton.widthAnchor constraintEqualToConstant:200],
+        [self.loadDeferredButton.heightAnchor constraintEqualToConstant:44],
         [self.autoRefreshButton.widthAnchor constraintEqualToConstant:200],
         [self.autoRefreshButton.heightAnchor constraintEqualToConstant:44]
     ]];
@@ -123,10 +139,15 @@
 
 - (void)loadBannerAd {
     self.receivedCallbacks = AdCallbackEventNone;
+    [self resetDeferredButtonState];
     if (self.isLoading) {
         [self showAlertWithTitle:@"Info" message:@"Banner is already loading."];
         return;
     }
+    
+    [self.deferredBannerAd removeFromSuperview];
+    [self.deferredBannerAd destroy];
+    self.deferredBannerAd = nil;
     
     if (!self.bannerAd) {
         [self createAndAddBannerToView];
@@ -140,6 +161,54 @@
     self.isLoading = YES;
     [self updateStatusUIWithState:AdStateLoading];
     [self.bannerAd load];
+}
+
+- (void)loadBannerDeferred {
+    self.receivedCallbacks = AdCallbackEventNone;
+    if (self.isLoading) {
+        [self showAlertWithTitle:@"Info" message:@"Banner is already loading."];
+        return;
+    }
+    
+    [self.bannerAd removeFromSuperview];
+    [self.bannerAd destroy];
+    self.bannerAd = nil;
+    [self.deferredBannerAd removeFromSuperview];
+    [self.deferredBannerAd destroy];
+    self.deferredBannerAd = nil;
+    self.isDeferredLoad = YES;
+    
+    NSString *adUnitId = [self adUnitId];
+    if (_settings.bannerAdUnitId.length > 0) {
+        adUnitId = _settings.bannerAdUnitId;
+    }
+    
+    self.deferredBannerAd = [[CloudXCore shared] createBannerWithAdUnitId:adUnitId];
+    self.deferredBannerAd.delegate = self;
+    self.deferredBannerAd.revenueDelegate = self;
+    self.deferredBannerAd.placement = @"demo_banner";
+    self.deferredBannerAd.customData = @"screen:home,position:bottom";
+    
+    self.isLoading = YES;
+    [self updateStatusUIWithState:AdStateLoading];
+    [self.deferredBannerAd load];
+}
+
+- (void)showDeferredBanner {
+    if (!self.isDeferredLoad || !self.deferredBannerAd) return;
+    self.isDeferredLoad = NO;
+    self.bannerAd = self.deferredBannerAd;
+    self.deferredBannerAd = nil;
+    [self addBannerToViewHierarchy];
+    [self resetDeferredButtonState];
+}
+
+- (void)resetDeferredButtonState {
+    self.isDeferredLoad = NO;
+    [self.loadDeferredButton setTitle:@"Load (Deferred)" forState:UIControlStateNormal];
+    self.loadDeferredButton.backgroundColor = [UIColor systemBlueColor];
+    [self.loadDeferredButton removeTarget:self action:@selector(showDeferredBanner) forControlEvents:UIControlEventTouchUpInside];
+    [self.loadDeferredButton addTarget:self action:@selector(loadBannerDeferred) forControlEvents:UIControlEventTouchUpInside];
 }
 
 - (void)createAndAddBannerToView {
@@ -224,9 +293,15 @@
         [self.bannerAd removeFromSuperview];
         [self.bannerAd destroy];
     }
+    if (self.deferredBannerAd) {
+        [self.deferredBannerAd removeFromSuperview];
+        [self.deferredBannerAd destroy];
+    }
     self.bannerAd = nil;
+    self.deferredBannerAd = nil;
     self.isLoading = NO;
     self.receivedCallbacks = AdCallbackEventNone;
+    [self resetDeferredButtonState];
     [self updateStatusUIWithState:AdStateNoAd];
 }
 
@@ -237,7 +312,12 @@
     self.isLoading = NO;
     [self updateStatusUIWithState:AdStateReady];
     
-    // Don't auto-show - user must press Show Banner button
+    if (self.isDeferredLoad) {
+        [self.loadDeferredButton setTitle:@"Show Banner" forState:UIControlStateNormal];
+        self.loadDeferredButton.backgroundColor = [UIColor systemOrangeColor];
+        [self.loadDeferredButton removeTarget:self action:@selector(loadBannerDeferred) forControlEvents:UIControlEventTouchUpInside];
+        [self.loadDeferredButton addTarget:self action:@selector(showDeferredBanner) forControlEvents:UIControlEventTouchUpInside];
+    }
 }
 
 - (void)didFailToLoadAd:(NSString *)adUnitId error:(CLXError *)error {
@@ -246,6 +326,8 @@
     self.isLoading = NO;
     [self updateStatusUIWithState:AdStateNoAd];
     self.bannerAd = nil;
+    self.deferredBannerAd = nil;
+    [self resetDeferredButtonState];
     
     dispatch_async(dispatch_get_main_queue(), ^{
         NSString *errorMessage = error ? [error detailedDemoDescription] : @"Unknown error occurred";
@@ -288,7 +370,7 @@
 }
 
 - (nullable UIView *)adViewForClickTesting {
-    return self.bannerAd;
+    return self.bannerAd ?: self.deferredBannerAd;
 }
 
 @end 

--- a/demo-app-swift/CloudXSwiftRemotePods/DeepLinkRouter.swift
+++ b/demo-app-swift/CloudXSwiftRemotePods/DeepLinkRouter.swift
@@ -13,6 +13,7 @@ enum DeepLinkRouter {
 
     fileprivate static let classNameMap: [String: String] = [
         "banner":                "BannerViewController",
+        "banner_deferred":       "BannerViewController",
         "mrec":                  "MRECViewController",
         "interstitial":          "InterstitialViewController",
         "rewarded":              "RewardedViewController",
@@ -59,7 +60,7 @@ private final class Adapter: NSObject, CLXTestHarnessApp {
     // MARK: - Format Configuration
 
     func supportedFormats() -> [String] {
-        ["banner", "mrec", "interstitial", "rewarded"]
+        ["banner", "banner_deferred", "mrec", "interstitial", "rewarded"]
     }
 
     func isFullscreenFormat(_ format: String) -> Bool {
@@ -69,6 +70,7 @@ private final class Adapter: NSObject, CLXTestHarnessApp {
     func loadSelector(forFormat format: String) -> Selector? {
         switch format {
         case "banner":                return NSSelectorFromString("loadBannerAd")
+        case "banner_deferred":       return NSSelectorFromString("loadBannerDeferred")
         case "mrec":                  return NSSelectorFromString("loadMRECAd")
         case "interstitial":          return NSSelectorFromString("loadInterstitialAd")
         case "rewarded":              return NSSelectorFromString("loadRewardedAd")
@@ -78,6 +80,7 @@ private final class Adapter: NSObject, CLXTestHarnessApp {
 
     func showSelector(forFormat format: String) -> Selector? {
         switch format {
+        case "banner_deferred":       return NSSelectorFromString("showDeferredBanner")
         case "interstitial":          return NSSelectorFromString("showInterstitialAd")
         case "rewarded":              return NSSelectorFromString("showRewardedAd")
         default:                      return nil

--- a/demo-app-swift/CloudXSwiftRemotePods/Views/Ad/BannerViewController.swift
+++ b/demo-app-swift/CloudXSwiftRemotePods/Views/Ad/BannerViewController.swift
@@ -3,8 +3,11 @@ import CloudXCore
 
 class BannerViewController: BaseAdViewController {
     private var bannerAd: CLXBannerAdView?
+    private var deferredBannerAd: CLXBannerAdView?
     private var autoRefreshButton: UIButton!
+    private var loadDeferredButton: UIButton!
     private var autoRefreshEnabled = true
+    private var isDeferredLoad = false
     private let settings = UserDefaultsSettings.shared
     
     override func viewDidLoad() {
@@ -33,6 +36,17 @@ class BannerViewController: BaseAdViewController {
         loadButton.translatesAutoresizingMaskIntoConstraints = false
         buttonStack.addArrangedSubview(loadButton)
         
+        // Load (Deferred) button — loads without adding to hierarchy
+        loadDeferredButton = UIButton(type: .system)
+        loadDeferredButton.setTitle("Load (Deferred)", for: .normal)
+        loadDeferredButton.addTarget(self, action: #selector(loadBannerDeferred), for: .touchUpInside)
+        loadDeferredButton.backgroundColor = .systemBlue
+        loadDeferredButton.setTitleColor(.white, for: .normal)
+        loadDeferredButton.titleLabel?.font = .boldSystemFont(ofSize: 16)
+        loadDeferredButton.layer.cornerRadius = 8
+        loadDeferredButton.translatesAutoresizingMaskIntoConstraints = false
+        buttonStack.addArrangedSubview(loadDeferredButton)
+        
         // Auto-refresh toggle button
         autoRefreshButton = UIButton(type: .system)
         autoRefreshButton.setTitle("Stop Auto-Refresh", for: .normal)
@@ -50,6 +64,8 @@ class BannerViewController: BaseAdViewController {
             buttonStack.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 100),
             loadButton.widthAnchor.constraint(equalToConstant: 200),
             loadButton.heightAnchor.constraint(equalToConstant: 44),
+            loadDeferredButton.widthAnchor.constraint(equalToConstant: 200),
+            loadDeferredButton.heightAnchor.constraint(equalToConstant: 44),
             autoRefreshButton.widthAnchor.constraint(equalToConstant: 200),
             autoRefreshButton.heightAnchor.constraint(equalToConstant: 44)
         ])
@@ -65,10 +81,15 @@ class BannerViewController: BaseAdViewController {
     
     @objc private func loadBannerAd() {
         receivedCallbacks = []
+        resetDeferredButtonState()
         if isLoading {
             showAlert(title: "Info", message: "Banner is already loading.")
             return
         }
+        
+        deferredBannerAd?.removeFromSuperview()
+        deferredBannerAd?.destroy()
+        deferredBannerAd = nil
         
         if bannerAd == nil {
             createAndAddBannerToView()
@@ -81,6 +102,45 @@ class BannerViewController: BaseAdViewController {
         isLoading = true
         updateStatusUI(state: .loading)
         bannerAd.load()
+    }
+    
+    @objc func loadBannerDeferred() {
+        receivedCallbacks = []
+        if isLoading {
+            showAlert(title: "Info", message: "Banner is already loading.")
+            return
+        }
+        
+        bannerAd?.removeFromSuperview()
+        bannerAd?.destroy()
+        bannerAd = nil
+        deferredBannerAd?.removeFromSuperview()
+        deferredBannerAd?.destroy()
+        deferredBannerAd = nil
+        isDeferredLoad = true
+        
+        var adUnitId = CLXDemoConfigManager.sharedManager.currentConfig.bannerAdUnitId
+        if !settings.bannerAdUnitId.isEmpty {
+            adUnitId = settings.bannerAdUnitId
+        }
+        deferredBannerAd = cloudX.createBanner(adUnitId: adUnitId)
+        deferredBannerAd?.delegate = self
+        deferredBannerAd?.revenueDelegate = self
+        deferredBannerAd?.placement = "demo_banner"
+        deferredBannerAd?.customData = "screen:home,position:bottom"
+        
+        isLoading = true
+        updateStatusUI(state: .loading)
+        deferredBannerAd?.load()
+    }
+    
+    @objc func showDeferredBanner() {
+        guard isDeferredLoad, let deferredBannerAd else { return }
+        isDeferredLoad = false
+        bannerAd = deferredBannerAd
+        self.deferredBannerAd = nil
+        addBannerToViewHierarchy()
+        resetDeferredButtonState()
     }
     
     @objc private func toggleAutoRefresh() {
@@ -146,16 +206,28 @@ class BannerViewController: BaseAdViewController {
         NotificationCenter.default.removeObserver(self)
     }
     
+    private func resetDeferredButtonState() {
+        isDeferredLoad = false
+        loadDeferredButton?.setTitle("Load (Deferred)", for: .normal)
+        loadDeferredButton?.backgroundColor = .systemBlue
+        loadDeferredButton?.removeTarget(self, action: #selector(showDeferredBanner), for: .touchUpInside)
+        loadDeferredButton?.addTarget(self, action: #selector(loadBannerDeferred), for: .touchUpInside)
+    }
+    
     private func resetAdState() {
         bannerAd?.removeFromSuperview()
         bannerAd?.destroy()
         bannerAd = nil
+        deferredBannerAd?.removeFromSuperview()
+        deferredBannerAd?.destroy()
+        deferredBannerAd = nil
         isLoading = false
         receivedCallbacks = []
+        resetDeferredButtonState()
         updateStatusUI(state: .noAd)
     }
 
-    override func adViewForClickTesting() -> UIView? { bannerAd }
+    override func adViewForClickTesting() -> UIView? { bannerAd ?? deferredBannerAd }
 }
 
 extension BannerViewController: CLXBannerDelegate, CLXAdRevenueDelegate {
@@ -163,6 +235,13 @@ extension BannerViewController: CLXBannerDelegate, CLXAdRevenueDelegate {
         DemoAppLogger.sharedInstance.logAdEvent("✅ Banner didLoadAd", ad: ad)
         isLoading = false
         updateStatusUI(state: .ready)
+        
+        if isDeferredLoad {
+            loadDeferredButton.setTitle("Show Banner", for: .normal)
+            loadDeferredButton.backgroundColor = .systemOrange
+            loadDeferredButton.removeTarget(self, action: #selector(loadBannerDeferred), for: .touchUpInside)
+            loadDeferredButton.addTarget(self, action: #selector(showDeferredBanner), for: .touchUpInside)
+        }
     }
     
     func didFailToLoadAd(_ adUnitId: String, error: CLXError) {
@@ -170,6 +249,8 @@ extension BannerViewController: CLXBannerDelegate, CLXAdRevenueDelegate {
         isLoading = false
         updateStatusUI(state: .noAd)
         bannerAd = nil
+        deferredBannerAd = nil
+        resetDeferredButtonState()
         
         DispatchQueue.main.async { [weak self] in
             let errorMessage = (error as NSError).detailedDemoDescription


### PR DESCRIPTION
## Summary
- add a `Load (Deferred)` button flow in Swift and ObjC banner demo screens
- switch deferred mode to `Show Banner` after successful load and attach the prefetched banner view on demand
- extend deep-link harness routing with `banner_deferred` load/show selectors for automation coverage

## Test plan
- [ ] launch Swift demo and run deferred banner flow: Load (Deferred) -> Show Banner
- [ ] launch ObjC demo and run deferred banner flow: Load (Deferred) -> Show Banner
- [ ] run harness scenario with `format=banner_deferred` to verify load then show selectors execute

Made with [Cursor](https://cursor.com)