### PR TITLE
Guard test harness imports with conditional compilation

### DIFF
--- a/demo-app-objc/CloudXObjCRemotePods/CLXDeepLinkRouter.m
+++ b/demo-app-objc/CloudXObjCRemotePods/CLXDeepLinkRouter.m
@@ -1,4 +1,6 @@
 #import "CLXDeepLinkRouter.h"
+
+#if __has_include(<CloudXTestHarness/CLXTestHarness.h>)
 #import "AdDemoTabViewController.h"
 #import "BaseAdViewController.h"
 #import "DemoAppLogger.h"
@@ -275,3 +277,14 @@ static NSDictionary<NSString *, NSString *> *classNameMap(void) {
 }
 
 @end
+
+#else
+
+// CloudXTestHarness not available — provide no-op stubs so the app compiles without the QA pod.
+@implementation CLXDeepLinkRouter
++ (void)setup {}
++ (BOOL)handleURL:(NSURL *)url { return NO; }
++ (void)handleLaunchArguments {}
+@end
+
+#endif

--- a/demo-app-swift/CloudXSwiftRemotePods/DeepLinkRouter.swift
+++ b/demo-app-swift/CloudXSwiftRemotePods/DeepLinkRouter.swift
@@ -1,12 +1,8 @@
 import UIKit
+
+#if canImport(CloudXTestHarness)
 import CloudXTestHarness
 
-/// App-specific adapter that bridges the demo app to CLXTestHarnessEngine.
-///
-/// Implements CLXTestHarnessApp to provide app-specific details
-/// (tab navigation, format-to-selector mapping, ad state queries, logging).
-/// All generic automation logic (dismiss detection, click testing, polling,
-/// synthetic UITouch) lives in the CloudXTestHarness pod.
 private let kSDKInitTimeout: TimeInterval = 30.0
 
 enum DeepLinkRouter {
@@ -18,7 +14,6 @@ enum DeepLinkRouter {
         "rewarded":              "RewardedViewController",
     ]
 
-    /// Register the adapter and forward launch arguments.
     static func setup() {
         CLXTestHarnessEngine.register(Adapter.shared)
     }
@@ -230,3 +225,15 @@ private final class Adapter: NSObject, CLXTestHarnessApp {
             .first { $0.isKeyWindow }
     }
 }
+
+#else
+
+// CloudXTestHarness not available — provide no-op stubs so the app compiles without the QA pod.
+enum DeepLinkRouter {
+    static func setup() {}
+    static func handleLaunchArguments() {}
+    @discardableResult
+    static func handleURL(_ url: URL) -> Bool { false }
+}
+
+#endif


### PR DESCRIPTION
## Summary
- Wraps `CloudXTestHarness` imports in `CLXDeepLinkRouter.m` (`__has_include`) and `DeepLinkRouter.swift` (`canImport`) with conditional compilation
- Provides no-op stubs when the QA pod is absent, so demo apps build in both production and QA configurations
- Fixes build failure when Podfile uses `~> 2.2.7` version specifiers without the test harness pod

## Test plan
- [x] ObjC demo app builds without CloudXTestHarness pod
- [x] Swift demo app builds without CloudXTestHarness pod

Made with [Cursor](https://cursor.com)