### PR TITLE
Release 2.2.8.1 (SPM-only)

### DIFF
--- a/adapter-inmobi/CloudXInMobiAdapter.podspec
+++ b/adapter-inmobi/CloudXInMobiAdapter.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'CloudXInMobiAdapter'
-  s.version = '2.2.8'
+  s.version = '2.2.8.1'
   s.summary          = 'CloudX InMobi Adapter - Static Framework'
   s.description      = 'InMobi adapter for CloudX iOS SDK - binary distribution'
   s.homepage         = 'https://github.com/cloudx-io/cloudx-ios'
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.vendored_frameworks = 'adapter-inmobi/CloudXInMobiAdapter.xcframework'
   
   # Dependencies
-  s.dependency 'CloudXCore', '2.2.8'
+  s.dependency 'CloudXCore', '2.2.8.1'
   s.dependency 'InMobiSDK', '>= 11.0.0', '< 12.0'
   
   s.frameworks = ['AVFoundation', 'AVKit', 'AdSupport', 'CoreGraphics', 'CoreLocation', 'CoreTelephony', 'Foundation', 'StoreKit', 'SystemConfiguration', 'UIKit']

--- a/adapter-inmobi/Package.swift
+++ b/adapter-inmobi/Package.swift
@@ -1,0 +1,23 @@
+// swift-tools-version: 5.9
+// Requires Xcode 15+
+import PackageDescription
+
+let package = Package(
+    name: "CloudXInMobiAdapter",
+    platforms: [
+        .iOS(.v13)
+    ],
+    products: [
+        .library(
+            name: "CloudXInMobiAdapter",
+            targets: ["CloudXInMobiAdapter"]
+        ),
+    ],
+    targets: [
+        .binaryTarget(
+            name: "CloudXInMobiAdapter",
+            url: "https://github.com/cloudx-io/cloudx-ios/releases/download/v2.2.8.1/CloudXInMobiAdapter.xcframework.zip",
+            checksum: "111b3b11f9e11f4dbc2e081033f877b3b41f7a75967ac9fd9767b1cb0e85c760"
+        ),
+    ]
+)

--- a/adapter-meta/CloudXMetaAdapter.podspec
+++ b/adapter-meta/CloudXMetaAdapter.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'CloudXMetaAdapter'
-  s.version = '2.2.8'
+  s.version = '2.2.8.1'
   s.summary          = 'CloudX Meta Adapter - Static Framework'
   s.description      = 'Meta (Facebook Audience Network) adapter for CloudX iOS SDK - binary distribution'
   s.homepage         = 'https://github.com/cloudx-io/cloudx-ios'
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.vendored_frameworks = 'adapter-meta/CloudXMetaAdapter.xcframework'
   
   # Dependencies
-  s.dependency 'CloudXCore', '2.2.8'
+  s.dependency 'CloudXCore', '2.2.8.1'
   s.dependency 'FBAudienceNetwork', '>= 6.9.0', '< 7.0'
   
   s.frameworks = ['AVFoundation', 'AVKit', 'AdSupport', 'CoreGraphics', 'CoreLocation', 'CoreTelephony', 'Foundation', 'StoreKit', 'SystemConfiguration', 'UIKit']

--- a/adapter-meta/Package.swift
+++ b/adapter-meta/Package.swift
@@ -1,0 +1,23 @@
+// swift-tools-version: 5.9
+// Requires Xcode 15+
+import PackageDescription
+
+let package = Package(
+    name: "CloudXMetaAdapter",
+    platforms: [
+        .iOS(.v13)
+    ],
+    products: [
+        .library(
+            name: "CloudXMetaAdapter",
+            targets: ["CloudXMetaAdapter"]
+        ),
+    ],
+    targets: [
+        .binaryTarget(
+            name: "CloudXMetaAdapter",
+            url: "https://github.com/cloudx-io/cloudx-ios/releases/download/v2.2.8.1/CloudXMetaAdapter.xcframework.zip",
+            checksum: "fe8c78b47fffcd03dd100177d990f3e50241c7db54062a4af5db627c91c807a6"
+        ),
+    ]
+)

--- a/adapter-mintegral/CloudXMintegralAdapter.podspec
+++ b/adapter-mintegral/CloudXMintegralAdapter.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'CloudXMintegralAdapter'
-  s.version = '2.2.8'
+  s.version = '2.2.8.1'
   s.summary          = 'CloudX Mintegral Adapter - Static Framework'
   s.description      = 'Mintegral adapter for CloudX iOS SDK - binary distribution'
   s.homepage         = 'https://github.com/cloudx-io/cloudx-ios'
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.vendored_frameworks = 'adapter-mintegral/CloudXMintegralAdapter.xcframework'
 
   # Dependencies
-  s.dependency 'CloudXCore', '2.2.8'
+  s.dependency 'CloudXCore', '2.2.8.1'
   s.dependency 'MintegralAdSDK', '~> 8.0'
   s.dependency 'MintegralAdSDK/BidBannerAd', '~> 8.0'
   s.dependency 'MintegralAdSDK/BidNewInterstitialAd', '~> 8.0'

--- a/adapter-mintegral/Package.swift
+++ b/adapter-mintegral/Package.swift
@@ -1,0 +1,23 @@
+// swift-tools-version: 5.9
+// Requires Xcode 15+
+import PackageDescription
+
+let package = Package(
+    name: "CloudXMintegralAdapter",
+    platforms: [
+        .iOS(.v13)
+    ],
+    products: [
+        .library(
+            name: "CloudXMintegralAdapter",
+            targets: ["CloudXMintegralAdapter"]
+        ),
+    ],
+    targets: [
+        .binaryTarget(
+            name: "CloudXMintegralAdapter",
+            url: "https://github.com/cloudx-io/cloudx-ios/releases/download/v2.2.8.1/CloudXMintegralAdapter.xcframework.zip",
+            checksum: "010c45e368fe041c4e6852d36318c3b7788a39b657bde78bcdcddf9076b965ca"
+        ),
+    ]
+)

--- a/adapter-unityads/CloudXUnityAdsAdapter.podspec
+++ b/adapter-unityads/CloudXUnityAdsAdapter.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'CloudXUnityAdsAdapter'
-  s.version = '2.2.8'
+  s.version = '2.2.8.1'
   s.summary          = 'CloudX Unity Ads Adapter - Static Framework'
   s.description      = 'Unity Ads adapter for CloudX iOS SDK - binary distribution'
   s.homepage         = 'https://github.com/cloudx-io/cloudx-ios'
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.vendored_frameworks = 'adapter-unityads/CloudXUnityAdsAdapter.xcframework'
 
   # Dependencies
-  s.dependency 'CloudXCore', '2.2.8'
+  s.dependency 'CloudXCore', '2.2.8.1'
   s.dependency 'UnityAds', '~> 4.17.0'
 
   s.frameworks = ['Foundation', 'UIKit', 'WebKit', 'AVFoundation', 'CoreMedia',

--- a/adapter-unityads/Package.swift
+++ b/adapter-unityads/Package.swift
@@ -1,0 +1,23 @@
+// swift-tools-version: 5.9
+// Requires Xcode 15+
+import PackageDescription
+
+let package = Package(
+    name: "CloudXUnityAdsAdapter",
+    platforms: [
+        .iOS(.v13)
+    ],
+    products: [
+        .library(
+            name: "CloudXUnityAdsAdapter",
+            targets: ["CloudXUnityAdsAdapter"]
+        ),
+    ],
+    targets: [
+        .binaryTarget(
+            name: "CloudXUnityAdsAdapter",
+            url: "https://github.com/cloudx-io/cloudx-ios/releases/download/v2.2.8.1/CloudXUnityAdsAdapter.xcframework.zip",
+            checksum: "cbe0e95035dd0cdfb5cf95d09e751d064592b28a59b52e86dde2810a928f5db8"
+        ),
+    ]
+)

--- a/adapter-vungle/CloudXVungleAdapter.podspec
+++ b/adapter-vungle/CloudXVungleAdapter.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'CloudXVungleAdapter'
-  s.version = '2.2.8'
+  s.version = '2.2.8.1'
   s.summary          = 'CloudX Vungle Adapter - Static Framework'
   s.description      = 'Vungle/Liftoff adapter for CloudX iOS SDK - binary distribution'
   s.homepage         = 'https://github.com/cloudx-io/cloudx-ios'
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.vendored_frameworks = 'adapter-vungle/CloudXVungleAdapter.xcframework'
   
   # Dependencies
-  s.dependency 'CloudXCore', '2.2.8'
+  s.dependency 'CloudXCore', '2.2.8.1'
   # 7.4.0 floor: VungleBannerView APIs introduced in 7.4; versions 7.0–7.3 lack banner support
   s.dependency 'VungleAds', '>= 7.4.0', '< 8.0'
   

--- a/adapter-vungle/Package.swift
+++ b/adapter-vungle/Package.swift
@@ -1,0 +1,23 @@
+// swift-tools-version: 5.9
+// Requires Xcode 15+
+import PackageDescription
+
+let package = Package(
+    name: "CloudXVungleAdapter",
+    platforms: [
+        .iOS(.v13)
+    ],
+    products: [
+        .library(
+            name: "CloudXVungleAdapter",
+            targets: ["CloudXVungleAdapter"]
+        ),
+    ],
+    targets: [
+        .binaryTarget(
+            name: "CloudXVungleAdapter",
+            url: "https://github.com/cloudx-io/cloudx-ios/releases/download/v2.2.8.1/CloudXVungleAdapter.xcframework.zip",
+            checksum: "7e1d736b04874ea1c6c25f25f93d4298f618478a982f4b6d0a8f2dc4eaaa595a"
+        ),
+    ]
+)

--- a/core/CloudXCore.podspec
+++ b/core/CloudXCore.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'CloudXCore'
-  s.version = '2.2.8'
+  s.version = '2.2.8.1'
   s.summary          = 'CloudX Core Framework'
   s.description      = 'Core framework for CloudX functionality - binary distribution'
   s.homepage         = 'https://github.com/cloudx-io/cloudx-ios'

--- a/core/Package.swift
+++ b/core/Package.swift
@@ -1,26 +1,23 @@
 // swift-tools-version: 5.9
-
+// Requires Xcode 15+
 import PackageDescription
 
 let package = Package(
     name: "CloudXCore",
     platforms: [
-        .iOS(.v14)
+        .iOS(.v13)
     ],
     products: [
         .library(
             name: "CloudXCore",
             targets: ["CloudXCore"]
-        )
+        ),
     ],
     targets: [
         .binaryTarget(
             name: "CloudXCore",
-            url: "https://github.com/cloudx-io/cloudx-ios/releases/download/v1.1.57-core/CloudXCore.xcframework.zip",
-            checksum: "PLACEHOLDER_CHECKSUM_TO_BE_UPDATED_BY_RELEASE_WORKFLOW"
-        )
+            url: "https://github.com/cloudx-io/cloudx-ios/releases/download/v2.2.8.1/CloudXCore.xcframework.zip",
+            checksum: "e215f429a5f7adb4cc26aaf35864a869e5b9150496d4e0977ff07bf048b71774"
+        ),
     ]
 )
-
-
-

--- a/renderer-cloudx/CloudXRenderer.podspec
+++ b/renderer-cloudx/CloudXRenderer.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'CloudXRenderer'
-  s.version = '2.2.8'
+  s.version = '2.2.8.1'
   s.summary          = 'CloudX Renderer Framework - Dynamic Framework'
   s.description      = 'Rendering engine for CloudX iOS SDK - binary distribution as dynamic framework'
   s.homepage         = 'https://github.com/cloudx-io/cloudx-ios'
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.vendored_frameworks = 'renderer-cloudx/CloudXRenderer.xcframework'
   
   # Dependencies
-  s.dependency 'CloudXCore', '2.2.8'
+  s.dependency 'CloudXCore', '2.2.8.1'
   
   s.frameworks = ['Foundation', 'UIKit', 'WebKit', 'AVFoundation', 'AVKit']
   s.weak_frameworks = ['SafariServices']

--- a/renderer-cloudx/Package.swift
+++ b/renderer-cloudx/Package.swift
@@ -1,0 +1,23 @@
+// swift-tools-version: 5.9
+// Requires Xcode 15+
+import PackageDescription
+
+let package = Package(
+    name: "CloudXRenderer",
+    platforms: [
+        .iOS(.v13)
+    ],
+    products: [
+        .library(
+            name: "CloudXRenderer",
+            targets: ["CloudXRenderer"]
+        ),
+    ],
+    targets: [
+        .binaryTarget(
+            name: "CloudXRenderer",
+            url: "https://github.com/cloudx-io/cloudx-ios/releases/download/v2.2.8.1/CloudXRenderer.xcframework.zip",
+            checksum: "b9656cfb5382389c5445bec9dbd80a6b7e45993c336ea0ad52fb85a02215a94f"
+        ),
+    ]
+)


### PR DESCRIPTION
## Summary

SPM-only patch release. Same v2.2.8 xcframework binaries — no rebuild, no functional changes. Enables Swift Package Manager installation for publishers. CocoaPods stays at 2.2.8 untouched.

## What changed

**Modified:**
- 7 podspecs: bumped version `2.2.8` → `2.2.8.1`
- 6 adapter podspecs: bumped CloudXCore dependency `2.2.8` → `2.2.8.1`
- `core/Package.swift`: was outdated (pointing to v1.1.57 with placeholder checksum) — now points to v2.2.8.1 with real checksum, iOS 13

**New files (6):**
- `adapter-meta/Package.swift`
- `adapter-vungle/Package.swift`
- `adapter-inmobi/Package.swift`
- `adapter-mintegral/Package.swift`
- `adapter-unityads/Package.swift`
- `renderer-cloudx/Package.swift`

All Package.swift files use `.binaryTarget` pointing to `v2.2.8.1` GitHub release assets with checksums computed via `swift package compute-checksum`.

## Why

This is the test run for the SPM release flow added in cloudx-io/cloudx-ios-private#497. Bryan asked for an SPM-only patch release to validate the flow without disturbing CocoaPods publishing.

## Release flow

After merge:
1. Tag `v2.2.8.1` on this commit
2. Create GitHub release `v2.2.8.1` with the existing v2.2.8 xcframework zips uploaded as release assets
3. **SKIP** `pod trunk push` — CocoaPods stays at 2.2.8
4. Test SPM install from a fresh Xcode project

CXD-295