### PR TITLE
feat: re-add native ad demo screens to public demo apps

### DIFF
--- a/demo-app-objc/CloudXObjCRemotePods/CLXDeepLinkRouter.m
+++ b/demo-app-objc/CloudXObjCRemotePods/CLXDeepLinkRouter.m
@@ -47,7 +47,10 @@ static NSDictionary<NSString *, NSString *> *classNameMap(void) {
 
     if ([format isEqualToString:@"native"]) {
         UINavigationController *navVC = contentVC.navigationController;
-        if (!navVC) return nil;
+        if (!navVC) {
+            [self logMessage:@"Native tab has no UINavigationController — cannot push NativeViewController"];
+            return nil;
+        }
         NativeViewController *nativeVC = [[NativeViewController alloc] init];
         [navVC pushViewController:nativeVC animated:NO];
         return nativeVC;
@@ -79,7 +82,7 @@ static NSDictionary<NSString *, NSString *> *classNameMap(void) {
     if ([format isEqualToString:@"mrec"])                  return @selector(loadMRECAd);
     if ([format isEqualToString:@"interstitial"])           return @selector(loadInterstitialAd);
     if ([format isEqualToString:@"rewarded"])               return @selector(loadRewardedAd);
-    if ([format isEqualToString:@"native"])                return @selector(loadNativeAd);
+    if ([format isEqualToString:@"native"])                 return @selector(loadNativeAd);
     return nil;
 }
 

--- a/demo-app-objc/CloudXObjCRemotePods/CLXDeepLinkRouter.m
+++ b/demo-app-objc/CloudXObjCRemotePods/CLXDeepLinkRouter.m
@@ -3,6 +3,7 @@
 #if __has_include(<CloudXTestHarness/CLXTestHarness.h>)
 #import "AdDemoTabViewController.h"
 #import "BaseAdViewController.h"
+#import "NativeViewController.h"
 #import "DemoAppLogger.h"
 #import <CloudXTestHarness/CLXTestHarness.h>
 
@@ -19,6 +20,7 @@ static NSDictionary<NSString *, NSString *> *classNameMap(void) {
             @"mrec":                   @"MRECViewController",
             @"interstitial":           @"InterstitialViewController",
             @"rewarded":               @"RewardedViewController",
+            @"native":                 @"NativeMenuViewController",
         };
     });
     return map;
@@ -41,7 +43,17 @@ static NSDictionary<NSString *, NSString *> *classNameMap(void) {
     if (tabIndex < 0) return nil;
 
     [tabVC selectTabIndex:tabIndex];
-    return [self vcAtTabIndex:tabIndex inTabVC:tabVC];
+    UIViewController *contentVC = [self vcAtTabIndex:tabIndex inTabVC:tabVC];
+
+    if ([format isEqualToString:@"native"]) {
+        UINavigationController *navVC = contentVC.navigationController;
+        if (!navVC) return nil;
+        NativeViewController *nativeVC = [[NativeViewController alloc] init];
+        [navVC pushViewController:nativeVC animated:NO];
+        return nativeVC;
+    }
+
+    return contentVC;
 }
 
 - (nullable UIViewController *)navigateToInit {
@@ -54,7 +66,7 @@ static NSDictionary<NSString *, NSString *> *classNameMap(void) {
 #pragma mark - Format Configuration
 
 - (NSArray<NSString *> *)supportedFormats {
-    return @[@"banner", @"mrec", @"interstitial", @"rewarded"];
+    return @[@"banner", @"mrec", @"interstitial", @"rewarded", @"native"];
 }
 
 - (BOOL)isFullscreenFormat:(NSString *)format {
@@ -67,6 +79,7 @@ static NSDictionary<NSString *, NSString *> *classNameMap(void) {
     if ([format isEqualToString:@"mrec"])                  return @selector(loadMRECAd);
     if ([format isEqualToString:@"interstitial"])           return @selector(loadInterstitialAd);
     if ([format isEqualToString:@"rewarded"])               return @selector(loadRewardedAd);
+    if ([format isEqualToString:@"native"])                return @selector(loadNativeAd);
     return nil;
 }
 

--- a/demo-app-objc/CloudXObjCRemotePods/Views/Ad/AdDemoTabViewController.m
+++ b/demo-app-objc/CloudXObjCRemotePods/Views/Ad/AdDemoTabViewController.m
@@ -4,6 +4,7 @@
 #import "InterstitialViewController.h"
 #import "RewardedViewController.h"
 #import "MRECViewController.h"
+#import "NativeMenuViewController.h"
 #import "SettingsViewController.h"
 #import "KeyValueDemoViewController.h"
 
@@ -27,21 +28,25 @@
     
     MRECViewController *mrecVC = [[MRECViewController alloc] init];
     mrecVC.tabBarItem = [[UITabBarItem alloc] initWithTitle:@"MREC" image:[UIImage systemImageNamed:@"rectangle.3.group"] tag:4];
-    
+
+    NativeMenuViewController *nativeVC = [[NativeMenuViewController alloc] init];
+    nativeVC.tabBarItem = [[UITabBarItem alloc] initWithTitle:@"Native" image:[UIImage systemImageNamed:@"doc.richtext"] tag:5];
+
     KeyValueDemoViewController *keyValueVC = [[KeyValueDemoViewController alloc] init];
-    keyValueVC.tabBarItem = [[UITabBarItem alloc] initWithTitle:@"Key-Values" image:[UIImage systemImageNamed:@"key.fill"] tag:5];
+    keyValueVC.tabBarItem = [[UITabBarItem alloc] initWithTitle:@"Key-Values" image:[UIImage systemImageNamed:@"key.fill"] tag:6];
     
     SettingsViewController *settinsVC = [[SettingsViewController alloc] init];
-    settinsVC.tabBarItem = [[UITabBarItem alloc] initWithTitle:@"Settings" image:[UIImage systemImageNamed:@"gearshape"] tag:6];
+    settinsVC.tabBarItem = [[UITabBarItem alloc] initWithTitle:@"Settings" image:[UIImage systemImageNamed:@"gearshape"] tag:7];
 
     
-    // Set view controllers
+    // Set view controllers - Additional VCs appear in "More" section
     self.viewControllers = @[
         [[UINavigationController alloc] initWithRootViewController:initInternalVC],
         [[UINavigationController alloc] initWithRootViewController:bannerVC],
         [[UINavigationController alloc] initWithRootViewController:interstitialVC],
         [[UINavigationController alloc] initWithRootViewController:rewardedVC],
         [[UINavigationController alloc] initWithRootViewController:mrecVC],
+        [[UINavigationController alloc] initWithRootViewController:nativeVC],
         [[UINavigationController alloc] initWithRootViewController:keyValueVC],
         [[UINavigationController alloc] initWithRootViewController:settinsVC]
     ];

--- a/demo-app-objc/CloudXObjCRemotePods/Views/Ad/NativeFeedViewController.h
+++ b/demo-app-objc/CloudXObjCRemotePods/Views/Ad/NativeFeedViewController.h
@@ -1,0 +1,9 @@
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface NativeFeedViewController : UIViewController
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/demo-app-objc/CloudXObjCRemotePods/Views/Ad/NativeFeedViewController.m
+++ b/demo-app-objc/CloudXObjCRemotePods/Views/Ad/NativeFeedViewController.m
@@ -1,0 +1,355 @@
+#import "NativeFeedViewController.h"
+#import <CloudXCore/CloudXCore.h>
+#import "CLXDemoConfigManager.h"
+#import "DemoAppLogger.h"
+#import "LogsModalViewController.h"
+#import "UserDefaultsSettings.h"
+
+static const NSInteger kAdCount = 10;
+static NSString * const kAdCellIdentifier = @"NativeAdCell";
+
+typedef NS_ENUM(NSInteger, NativeAdCreativeType) {
+    NativeAdCreativeTypeUnknown,
+    NativeAdCreativeTypeImage,
+    NativeAdCreativeTypeVideoLandscape,
+    NativeAdCreativeTypeVideoPortrait,
+};
+
+#pragma mark - NativeAdFeedItem
+
+@interface NativeAdFeedItem : NSObject
+@property (nonatomic, strong) CLXNativeAdLoader *loader;
+@property (nonatomic, strong, nullable) CLXNativeAdView *adView;
+@property (nonatomic, strong, nullable) CLXAd *ad;
+@property (nonatomic, assign) NativeAdCreativeType creativeType;
+@property (nonatomic, assign) BOOL isLoading;
+@property (nonatomic, assign) BOOL isLoaded;
+@property (nonatomic, assign) BOOL isFailed;
+@end
+
+@implementation NativeAdFeedItem
+@end
+
+#pragma mark - NativeFeedViewController
+
+@interface NativeFeedViewController () <UITableViewDataSource, UITableViewDelegate, CLXNativeAdDelegate, CLXAdRevenueDelegate>
+@property (nonatomic, strong) UITableView *tableView;
+@property (nonatomic, strong) NSMutableArray<NativeAdFeedItem *> *feedItems;
+@property (nonatomic, assign) NSInteger nextLoadIndex;
+@end
+
+@implementation NativeFeedViewController
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    self.title = @"Native Feed";
+    self.view.backgroundColor = [UIColor systemBackgroundColor];
+
+    [self setupTableView];
+    [self setupAppLogsButton];
+    [self createFeedItems];
+    [self loadNextAd];
+}
+
+- (void)dealloc {
+    for (NativeAdFeedItem *item in self.feedItems) {
+        [item.loader destroy];
+    }
+}
+
+#pragma mark - Setup
+
+- (void)setupTableView {
+    self.tableView = [[UITableView alloc] initWithFrame:CGRectZero style:UITableViewStylePlain];
+    self.tableView.translatesAutoresizingMaskIntoConstraints = NO;
+    self.tableView.dataSource = self;
+    self.tableView.delegate = self;
+    self.tableView.separatorStyle = UITableViewCellSeparatorStyleNone;
+    self.tableView.allowsSelection = NO;
+    [self.tableView registerClass:[UITableViewCell class] forCellReuseIdentifier:kAdCellIdentifier];
+    [self.view addSubview:self.tableView];
+
+    [NSLayoutConstraint activateConstraints:@[
+        [self.tableView.topAnchor constraintEqualToAnchor:self.view.topAnchor],
+        [self.tableView.leadingAnchor constraintEqualToAnchor:self.view.leadingAnchor],
+        [self.tableView.trailingAnchor constraintEqualToAnchor:self.view.trailingAnchor],
+        [self.tableView.bottomAnchor constraintEqualToAnchor:self.view.bottomAnchor],
+    ]];
+}
+
+- (void)setupAppLogsButton {
+    UIButton *logsButton = [UIButton buttonWithType:UIButtonTypeSystem];
+    [logsButton setTitle:@"App Logs" forState:UIControlStateNormal];
+    logsButton.titleLabel.font = [UIFont systemFontOfSize:14 weight:UIFontWeightMedium];
+    logsButton.backgroundColor = [UIColor systemOrangeColor];
+    [logsButton setTitleColor:[UIColor whiteColor] forState:UIControlStateNormal];
+    logsButton.layer.cornerRadius = 6;
+    logsButton.translatesAutoresizingMaskIntoConstraints = NO;
+    [logsButton addTarget:self action:@selector(showLogsModal) forControlEvents:UIControlEventTouchUpInside];
+    [self.view addSubview:logsButton];
+
+    [NSLayoutConstraint activateConstraints:@[
+        [logsButton.topAnchor constraintEqualToAnchor:self.view.safeAreaLayoutGuide.topAnchor constant:8],
+        [logsButton.trailingAnchor constraintEqualToAnchor:self.view.trailingAnchor constant:-12],
+        [logsButton.widthAnchor constraintEqualToConstant:90],
+        [logsButton.heightAnchor constraintEqualToConstant:30],
+    ]];
+}
+
+- (void)showLogsModal {
+    LogsModalViewController *logsModal = [[LogsModalViewController alloc] initWithTitle:@"Logs"];
+    logsModal.modalPresentationStyle = UIModalPresentationPageSheet;
+    [self presentViewController:logsModal animated:YES completion:nil];
+}
+
+- (NSString *)adUnitId {
+    NSString *adUnitId = [[CLXDemoConfigManager sharedManager] currentConfig].nativeAdUnitId;
+    if ([UserDefaultsSettings sharedSettings].nativeMediumAdUnitId.length > 0) {
+        adUnitId = [UserDefaultsSettings sharedSettings].nativeMediumAdUnitId;
+    }
+    return adUnitId;
+}
+
+- (void)createFeedItems {
+    self.feedItems = [NSMutableArray arrayWithCapacity:kAdCount];
+    self.nextLoadIndex = 0;
+
+    for (NSInteger i = 0; i < kAdCount; i++) {
+        NativeAdFeedItem *item = [[NativeAdFeedItem alloc] init];
+        item.loader = [[CloudXCore shared] createNativeAdLoaderWithAdUnitIdentifier:[self adUnitId]];
+        item.loader.nativeAdDelegate = self;
+        item.loader.revenueDelegate = self;
+        item.loader.placement = [NSString stringWithFormat:@"feed_slot_%ld", (long)i];
+        item.creativeType = NativeAdCreativeTypeUnknown;
+        [self.feedItems addObject:item];
+    }
+}
+
+#pragma mark - Sequential Loading
+
+- (void)loadNextAd {
+    if (self.nextLoadIndex >= kAdCount) return;
+
+    NativeAdFeedItem *item = self.feedItems[self.nextLoadIndex];
+    item.isLoading = YES;
+    [item.loader loadAd];
+}
+
+- (nullable NativeAdFeedItem *)feedItemForLoader:(CLXNativeAdLoader *)loader {
+    for (NativeAdFeedItem *item in self.feedItems) {
+        if (item.loader == loader) return item;
+    }
+    return nil;
+}
+
+- (NSInteger)indexForLoader:(CLXNativeAdLoader *)loader {
+    for (NSInteger i = 0; i < self.feedItems.count; i++) {
+        if (self.feedItems[i].loader == loader) return i;
+    }
+    return NSNotFound;
+}
+
+#pragma mark - Creative Type Detection
+
+- (NativeAdCreativeType)detectCreativeTypeFromAd:(CLXAd *)ad nativeAdView:(CLXNativeAdView *)adView {
+    CLXNativeAd *nativeAd = ad.nativeAd;
+    if (!nativeAd) return NativeAdCreativeTypeUnknown;
+
+    if (nativeAd.isVideoContent) {
+        CGFloat ar = nativeAd.mediaContentAspectRatio;
+        return (ar < 1.0) ? NativeAdCreativeTypeVideoPortrait : NativeAdCreativeTypeVideoLandscape;
+    }
+
+    return (nativeAd.mediaContentAspectRatio > 0) ? NativeAdCreativeTypeImage : NativeAdCreativeTypeUnknown;
+}
+
+- (NSString *)badgeTextForCreativeType:(NativeAdCreativeType)type {
+    switch (type) {
+        case NativeAdCreativeTypeImage: return @"IMAGE";
+        case NativeAdCreativeTypeVideoLandscape: return @"VIDEO 16:9";
+        case NativeAdCreativeTypeVideoPortrait: return @"REELS 9:16";
+        case NativeAdCreativeTypeUnknown: return @"UNKNOWN";
+    }
+}
+
+- (UIColor *)badgeColorForCreativeType:(NativeAdCreativeType)type {
+    switch (type) {
+        case NativeAdCreativeTypeImage: return [UIColor systemBlueColor];
+        case NativeAdCreativeTypeVideoLandscape: return [UIColor systemOrangeColor];
+        case NativeAdCreativeTypeVideoPortrait: return [UIColor systemPurpleColor];
+        case NativeAdCreativeTypeUnknown: return [UIColor systemGrayColor];
+    }
+}
+
+#pragma mark - CLXNativeAdDelegate
+
+- (void)didLoadNativeAd:(nullable CLXNativeAdView *)nativeAdView forAd:(CLXAd *)ad {
+    CLXNativeAdLoader *loader = nil;
+    for (NativeAdFeedItem *item in self.feedItems) {
+        if (item.isLoading && !item.isLoaded) {
+            loader = item.loader;
+            break;
+        }
+    }
+
+    NSInteger idx = self.nextLoadIndex;
+    if (idx >= kAdCount) return;
+
+    NativeAdFeedItem *item = self.feedItems[idx];
+    item.isLoading = NO;
+    item.isLoaded = YES;
+    item.ad = ad;
+
+    if (nativeAdView) {
+        item.adView = nativeAdView;
+    } else {
+        CLXNativeAdView *templateView = [CLXNativeAdView viewFromAd:ad.nativeAd];
+        [item.loader renderNativeAdView:templateView withAd:ad];
+        item.adView = templateView;
+    }
+
+    item.creativeType = [self detectCreativeTypeFromAd:ad nativeAdView:item.adView];
+
+    [[DemoAppLogger sharedInstance] logMessage:[NSString stringWithFormat:@"✅ Feed slot %ld loaded: %@", (long)idx, [self badgeTextForCreativeType:item.creativeType]]];
+
+    [self.tableView reloadRowsAtIndexPaths:@[[NSIndexPath indexPathForRow:idx inSection:0]]
+                          withRowAnimation:UITableViewRowAnimationFade];
+
+    self.nextLoadIndex++;
+    [self loadNextAd];
+}
+
+- (void)didFailToLoadNativeAdForAdUnitIdentifier:(NSString *)adUnitId error:(CLXError *)error {
+    NSInteger idx = self.nextLoadIndex;
+    if (idx >= kAdCount) return;
+
+    NativeAdFeedItem *item = self.feedItems[idx];
+    item.isLoading = NO;
+    item.isFailed = YES;
+
+    [[DemoAppLogger sharedInstance] logMessage:[NSString stringWithFormat:@"❌ Feed slot %ld failed: %@", (long)idx, error.localizedDescription]];
+
+    [self.tableView reloadRowsAtIndexPaths:@[[NSIndexPath indexPathForRow:idx inSection:0]]
+                          withRowAnimation:UITableViewRowAnimationFade];
+
+    self.nextLoadIndex++;
+    [self loadNextAd];
+}
+
+- (void)didClickNativeAd:(CLXAd *)ad {
+    [[DemoAppLogger sharedInstance] logAdEvent:@"👆 Feed didClickNativeAd" ad:ad];
+}
+
+- (void)didExpireNativeAd:(CLXAd *)ad {
+    [[DemoAppLogger sharedInstance] logAdEvent:@"⏰ Feed didExpireNativeAd" ad:ad];
+}
+
+#pragma mark - CLXAdRevenueDelegate
+
+- (void)didPayRevenueForAd:(CLXAd *)ad {
+    [[DemoAppLogger sharedInstance] logAdEvent:@"💰 Feed didPayRevenueForAd" ad:ad];
+}
+
+#pragma mark - UITableViewDataSource
+
+- (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
+    return kAdCount;
+}
+
+- (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
+    UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:kAdCellIdentifier forIndexPath:indexPath];
+
+    for (UIView *subview in cell.contentView.subviews) {
+        [subview removeFromSuperview];
+    }
+
+    NativeAdFeedItem *item = self.feedItems[indexPath.row];
+
+    if (item.isLoaded && item.adView) {
+        item.adView.translatesAutoresizingMaskIntoConstraints = NO;
+        [cell.contentView addSubview:item.adView];
+
+        [NSLayoutConstraint activateConstraints:@[
+            [item.adView.topAnchor constraintEqualToAnchor:cell.contentView.topAnchor constant:8],
+            [item.adView.leadingAnchor constraintEqualToAnchor:cell.contentView.leadingAnchor constant:12],
+            [item.adView.trailingAnchor constraintEqualToAnchor:cell.contentView.trailingAnchor constant:-12],
+            [item.adView.bottomAnchor constraintEqualToAnchor:cell.contentView.bottomAnchor constant:-8],
+        ]];
+
+        UILabel *badge = [[UILabel alloc] init];
+        badge.text = [NSString stringWithFormat:@" %@ ", [self badgeTextForCreativeType:item.creativeType]];
+        badge.font = [UIFont boldSystemFontOfSize:11];
+        badge.textColor = [UIColor whiteColor];
+        badge.backgroundColor = [self badgeColorForCreativeType:item.creativeType];
+        badge.layer.cornerRadius = 4;
+        badge.clipsToBounds = YES;
+        badge.translatesAutoresizingMaskIntoConstraints = NO;
+        [cell.contentView addSubview:badge];
+
+        UILabel *slotLabel = [[UILabel alloc] init];
+        slotLabel.text = [NSString stringWithFormat:@"Slot %ld", (long)indexPath.row];
+        slotLabel.font = [UIFont monospacedSystemFontOfSize:10 weight:UIFontWeightMedium];
+        slotLabel.textColor = [UIColor tertiaryLabelColor];
+        slotLabel.translatesAutoresizingMaskIntoConstraints = NO;
+        [cell.contentView addSubview:slotLabel];
+
+        [NSLayoutConstraint activateConstraints:@[
+            [badge.topAnchor constraintEqualToAnchor:cell.contentView.topAnchor constant:14],
+            [badge.trailingAnchor constraintEqualToAnchor:cell.contentView.trailingAnchor constant:-18],
+            [slotLabel.topAnchor constraintEqualToAnchor:cell.contentView.topAnchor constant:14],
+            [slotLabel.leadingAnchor constraintEqualToAnchor:cell.contentView.leadingAnchor constant:18],
+        ]];
+    } else if (item.isFailed) {
+        UILabel *errorLabel = [[UILabel alloc] init];
+        errorLabel.text = [NSString stringWithFormat:@"Slot %ld — Load Failed", (long)indexPath.row];
+        errorLabel.textColor = [UIColor systemRedColor];
+        errorLabel.font = [UIFont preferredFontForTextStyle:UIFontTextStyleSubheadline];
+        errorLabel.textAlignment = NSTextAlignmentCenter;
+        errorLabel.translatesAutoresizingMaskIntoConstraints = NO;
+        [cell.contentView addSubview:errorLabel];
+        [NSLayoutConstraint activateConstraints:@[
+            [errorLabel.centerXAnchor constraintEqualToAnchor:cell.contentView.centerXAnchor],
+            [errorLabel.centerYAnchor constraintEqualToAnchor:cell.contentView.centerYAnchor],
+        ]];
+    } else {
+        UIActivityIndicatorView *spinner = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleMedium];
+        spinner.translatesAutoresizingMaskIntoConstraints = NO;
+        [spinner startAnimating];
+        [cell.contentView addSubview:spinner];
+
+        UILabel *loadingLabel = [[UILabel alloc] init];
+        loadingLabel.text = [NSString stringWithFormat:@"Slot %ld — Loading...", (long)indexPath.row];
+        loadingLabel.textColor = [UIColor secondaryLabelColor];
+        loadingLabel.font = [UIFont preferredFontForTextStyle:UIFontTextStyleSubheadline];
+        loadingLabel.translatesAutoresizingMaskIntoConstraints = NO;
+        [cell.contentView addSubview:loadingLabel];
+
+        [NSLayoutConstraint activateConstraints:@[
+            [spinner.centerYAnchor constraintEqualToAnchor:cell.contentView.centerYAnchor],
+            [spinner.trailingAnchor constraintEqualToAnchor:loadingLabel.leadingAnchor constant:-8],
+            [loadingLabel.centerXAnchor constraintEqualToAnchor:cell.contentView.centerXAnchor constant:12],
+            [loadingLabel.centerYAnchor constraintEqualToAnchor:cell.contentView.centerYAnchor],
+        ]];
+    }
+
+    cell.backgroundColor = [UIColor clearColor];
+    cell.contentView.backgroundColor = [UIColor clearColor];
+    return cell;
+}
+
+#pragma mark - UITableViewDelegate
+
+- (CGFloat)tableView:(UITableView *)tableView heightForRowAtIndexPath:(NSIndexPath *)indexPath {
+    NativeAdFeedItem *item = self.feedItems[indexPath.row];
+
+    if (item.isLoaded) {
+        if (item.creativeType == NativeAdCreativeTypeVideoPortrait) {
+            return 600;
+        }
+        return 400;
+    }
+
+    return 80;
+}
+
+@end

--- a/demo-app-objc/CloudXObjCRemotePods/Views/Ad/NativeMenuViewController.h
+++ b/demo-app-objc/CloudXObjCRemotePods/Views/Ad/NativeMenuViewController.h
@@ -1,0 +1,9 @@
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface NativeMenuViewController : UITableViewController
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/demo-app-objc/CloudXObjCRemotePods/Views/Ad/NativeMenuViewController.m
+++ b/demo-app-objc/CloudXObjCRemotePods/Views/Ad/NativeMenuViewController.m
@@ -1,0 +1,98 @@
+#import "NativeMenuViewController.h"
+#import "NativeViewController.h"
+#import "NativeFeedViewController.h"
+#import "ReelsFeedViewController.h"
+#import <FBAudienceNetwork/FBAudienceNetwork.h>
+
+static NSString * const kCellIdentifier = @"MenuCell";
+
+typedef NS_ENUM(NSInteger, NativeMenuRow) {
+    NativeMenuRowSingleAd,
+    NativeMenuRowFeed,
+    NativeMenuRowReelsFeed,
+    NativeMenuRowCount
+};
+
+@implementation NativeMenuViewController
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    self.title = @"Native";
+    [self.tableView registerClass:[UITableViewCell class] forCellReuseIdentifier:kCellIdentifier];
+}
+
+#pragma mark - UITableViewDataSource
+
+- (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
+    return NativeMenuRowCount;
+}
+
+- (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
+    UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:kCellIdentifier forIndexPath:indexPath];
+    cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
+
+    if (@available(iOS 14.0, *)) {
+        UIListContentConfiguration *config = [UIListContentConfiguration cellConfiguration];
+        switch (indexPath.row) {
+            case NativeMenuRowSingleAd:
+                config.text = @"Single Ad — Image";
+                config.secondaryText = @"Template / Manual / Late-binding flows";
+                config.image = [UIImage systemImageNamed:@"photo"];
+                break;
+            case NativeMenuRowFeed:
+                config.text = @"Feed — Video 16:9";
+                config.secondaryText = @"Scrollable feed with landscape video ads";
+                config.image = [UIImage systemImageNamed:@"rectangle.stack"];
+                break;
+            case NativeMenuRowReelsFeed:
+                config.text = @"Reels — Video 9:16";
+                config.secondaryText = @"Full-screen vertical paging — swipe to advance";
+                config.image = [UIImage systemImageNamed:@"play.rectangle.fill"];
+                break;
+        }
+        cell.contentConfiguration = config;
+    } else {
+        switch (indexPath.row) {
+            case NativeMenuRowSingleAd:
+                cell.textLabel.text = @"Single Ad — Image";
+                break;
+            case NativeMenuRowFeed:
+                cell.textLabel.text = @"Feed — Video 16:9";
+                break;
+            case NativeMenuRowReelsFeed:
+                cell.textLabel.text = @"Reels — Video 9:16";
+                break;
+        }
+    }
+
+    return cell;
+}
+
+#pragma mark - UITableViewDelegate
+
+- (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
+    [tableView deselectRowAtIndexPath:indexPath animated:YES];
+
+    switch (indexPath.row) {
+        case NativeMenuRowSingleAd: {
+            [FBAdSettings setTestAdType:FBAdTestAdType_Img_16_9_App_Install];
+            NativeViewController *vc = [[NativeViewController alloc] init];
+            [self.navigationController pushViewController:vc animated:YES];
+            break;
+        }
+        case NativeMenuRowFeed: {
+            [FBAdSettings setTestAdType:FBAdTestAdType_Vid_HD_16_9_46s_App_Install];
+            NativeFeedViewController *vc = [[NativeFeedViewController alloc] init];
+            [self.navigationController pushViewController:vc animated:YES];
+            break;
+        }
+        case NativeMenuRowReelsFeed: {
+            [FBAdSettings setTestAdType:FBAdTestAdType_Vid_HD_9_16_39s_App_Install];
+            ReelsFeedViewController *vc = [[ReelsFeedViewController alloc] init];
+            [self.navigationController pushViewController:vc animated:YES];
+            break;
+        }
+    }
+}
+
+@end

--- a/demo-app-objc/CloudXObjCRemotePods/Views/Ad/NativeViewController.h
+++ b/demo-app-objc/CloudXObjCRemotePods/Views/Ad/NativeViewController.h
@@ -1,0 +1,10 @@
+#import "BaseAdViewController.h"
+#import <CloudXCore/CloudXCore.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface NativeViewController : BaseAdViewController <CLXNativeAdDelegate, CLXAdRevenueDelegate>
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/demo-app-objc/CloudXObjCRemotePods/Views/Ad/NativeViewController.m
+++ b/demo-app-objc/CloudXObjCRemotePods/Views/Ad/NativeViewController.m
@@ -239,12 +239,17 @@ typedef NS_ENUM(NSInteger, NativeFlow) {
 
 #pragma mark - Flow A: Template
 
+- (void)loadNativeAd {
+    [self loadTemplate];
+}
+
 - (void)loadTemplate {
     if (self.isLoading) {
         [self showAlertWithTitle:@"Info" message:@"Native ad is already loading."];
         return;
     }
     [self resetAdState];
+    self.receivedCallbacks = AdCallbackEventNone;
     self.activeFlow = NativeFlowTemplate;
     self.isLoading = YES;
     [self updateStatusUIWithState:AdStateLoading];
@@ -609,6 +614,7 @@ typedef NS_ENUM(NSInteger, NativeFlow) {
 - (void)didLoadNativeAd:(nullable CLXNativeAdView *)nativeAdView forAd:(CLXAd *)ad {
     [[DemoAppLogger sharedInstance] logAdEvent:@"✅ Native didLoadNativeAd" ad:ad];
     self.isLoading = NO;
+    self.receivedCallbacks |= AdCallbackEventLoaded;
     self.loadedAd = ad;
 
     if (self.activeFlow == NativeFlowLateBinding) {
@@ -646,6 +652,7 @@ typedef NS_ENUM(NSInteger, NativeFlow) {
 }
 
 - (void)didClickNativeAd:(CLXAd *)ad {
+    self.receivedCallbacks |= AdCallbackEventClicked;
     [[DemoAppLogger sharedInstance] logAdEvent:@"👆 Native didClickNativeAd" ad:ad];
 }
 
@@ -661,7 +668,12 @@ typedef NS_ENUM(NSInteger, NativeFlow) {
 #pragma mark - CLXAdRevenueDelegate
 
 - (void)didPayRevenueForAd:(CLXAd *)ad {
+    self.receivedCallbacks |= AdCallbackEventRevenueReceived;
     [[DemoAppLogger sharedInstance] logAdEvent:@"💰 Native didPayRevenueForAd" ad:ad];
+}
+
+- (nullable UIView *)adViewForClickTesting {
+    return self.nativeAdView;
 }
 
 - (void)updateStatusUIWithState:(AdState)state {

--- a/demo-app-objc/CloudXObjCRemotePods/Views/Ad/NativeViewController.m
+++ b/demo-app-objc/CloudXObjCRemotePods/Views/Ad/NativeViewController.m
@@ -265,6 +265,7 @@ typedef NS_ENUM(NSInteger, NativeFlow) {
         return;
     }
     [self resetAdState];
+    self.receivedCallbacks = AdCallbackEventNone;
     self.activeFlow = NativeFlowManual;
 
     CLXNativeAdView *adView = [self buildManualAdView];
@@ -293,6 +294,7 @@ typedef NS_ENUM(NSInteger, NativeFlow) {
         return;
     }
     [self resetAdState];
+    self.receivedCallbacks = AdCallbackEventNone;
     self.activeFlow = NativeFlowLateBinding;
     self.isLoading = YES;
     [self updateStatusUIWithState:AdStateLoading];

--- a/demo-app-objc/CloudXObjCRemotePods/Views/Ad/NativeViewController.m
+++ b/demo-app-objc/CloudXObjCRemotePods/Views/Ad/NativeViewController.m
@@ -1,0 +1,672 @@
+#import "NativeViewController.h"
+#import <CloudXCore/CloudXCore.h>
+#import "DemoAppLogger.h"
+#import "CLXDemoConfigManager.h"
+#import "UserDefaultsSettings.h"
+#import "NSError+DemoDescription.h"
+
+typedef NS_ENUM(NSInteger, NativeFlow) {
+    NativeFlowTemplate = 0,
+    NativeFlowManual = 1,
+    NativeFlowLateBinding = 2,
+};
+
+@interface NativeViewController ()
+@property (nonatomic, strong, nullable) CLXNativeAdLoader *nativeAdLoader;
+@property (nonatomic, strong, nullable) CLXNativeAdView *nativeAdView;
+@property (nonatomic, strong, nullable) CLXAd *loadedAd;
+@property (nonatomic, strong) UIScrollView *scrollView;
+@property (nonatomic, strong) UIStackView *contentStack;
+@property (nonatomic, strong) UIView *adContainerView;
+@property (nonatomic, assign) AdState adState;
+@property (nonatomic, strong) UserDefaultsSettings *settings;
+@property (nonatomic, assign) NativeFlow activeFlow;
+@property (nonatomic, strong) UISegmentedControl *flowPicker;
+@property (nonatomic, strong) UILabel *flowDescription;
+@property (nonatomic, strong) UIButton *loadButton;
+@property (nonatomic, strong) UIButton *bindButton;
+@property (nonatomic, strong) UIButton *destroyButton;
+@property (nonatomic, strong) UILabel *flowBanner;
+@property (nonatomic, strong, nullable) CLXAd *preloadedAd;
+@end
+
+@implementation NativeViewController
+
+#pragma mark - Lifecycle
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    self.title = @"Native";
+    self.settings = [UserDefaultsSettings sharedSettings];
+    self.activeFlow = NativeFlowTemplate;
+    [self setupUI];
+    [self updateStatusUIWithState:AdStateNoAd];
+    [self flowPickerChanged];
+}
+
+- (void)viewWillDisappear:(BOOL)animated {
+    [super viewWillDisappear:animated];
+    [self resetAdState];
+}
+
+- (void)dealloc {
+    [self.nativeAdLoader destroy];
+}
+
+#pragma mark - UI Setup
+
+- (void)setupUI {
+    self.flowDescription = [[UILabel alloc] init];
+    self.flowDescription.font = [UIFont systemFontOfSize:13 weight:UIFontWeightMedium];
+    self.flowDescription.textColor = [UIColor labelColor];
+    self.flowDescription.textAlignment = NSTextAlignmentLeft;
+    self.flowDescription.numberOfLines = 0;
+    self.flowDescription.translatesAutoresizingMaskIntoConstraints = NO;
+    [self.view addSubview:self.flowDescription];
+
+    [NSLayoutConstraint activateConstraints:@[
+        [self.flowDescription.topAnchor constraintEqualToAnchor:self.view.safeAreaLayoutGuide.topAnchor constant:8],
+        [self.flowDescription.leadingAnchor constraintEqualToAnchor:self.view.leadingAnchor constant:16],
+        [self.flowDescription.trailingAnchor constraintLessThanOrEqualToAnchor:self.view.trailingAnchor constant:-140],
+        [self.flowDescription.bottomAnchor constraintLessThanOrEqualToAnchor:self.view.safeAreaLayoutGuide.topAnchor constant:90],
+    ]];
+
+    self.scrollView = [[UIScrollView alloc] init];
+    self.scrollView.translatesAutoresizingMaskIntoConstraints = NO;
+    self.scrollView.alwaysBounceVertical = YES;
+    [self.view addSubview:self.scrollView];
+
+    self.contentStack = [[UIStackView alloc] init];
+    self.contentStack.axis = UILayoutConstraintAxisVertical;
+    self.contentStack.spacing = 6;
+    self.contentStack.alignment = UIStackViewAlignmentFill;
+    self.contentStack.translatesAutoresizingMaskIntoConstraints = NO;
+    [self.scrollView addSubview:self.contentStack];
+
+    self.flowPicker = [[UISegmentedControl alloc] initWithItems:@[@"A: Template", @"B: Manual", @"C: Late-Bind"]];
+    self.flowPicker.selectedSegmentIndex = 0;
+    [self.flowPicker addTarget:self action:@selector(flowPickerChanged) forControlEvents:UIControlEventValueChanged];
+    [self.contentStack addArrangedSubview:self.flowPicker];
+
+    UIStackView *buttonRow = [[UIStackView alloc] init];
+    buttonRow.axis = UILayoutConstraintAxisHorizontal;
+    buttonRow.spacing = 8;
+    buttonRow.alignment = UIStackViewAlignmentCenter;
+    buttonRow.distribution = UIStackViewDistributionFill;
+
+    UIView *leftSpacer = [[UIView alloc] init];
+    UIView *rightSpacer = [[UIView alloc] init];
+
+    self.loadButton = [UIButton buttonWithType:UIButtonTypeSystem];
+    [self.loadButton setTitleColor:[UIColor whiteColor] forState:UIControlStateNormal];
+    self.loadButton.titleLabel.font = [UIFont boldSystemFontOfSize:14];
+    self.loadButton.layer.cornerRadius = 8;
+    self.loadButton.translatesAutoresizingMaskIntoConstraints = NO;
+    [self.loadButton addTarget:self action:@selector(loadAction) forControlEvents:UIControlEventTouchUpInside];
+
+    self.destroyButton = [UIButton buttonWithType:UIButtonTypeSystem];
+    [self.destroyButton setTitle:@"Destroy" forState:UIControlStateNormal];
+    [self.destroyButton setTitleColor:[UIColor systemRedColor] forState:UIControlStateNormal];
+    self.destroyButton.titleLabel.font = [UIFont systemFontOfSize:13 weight:UIFontWeightMedium];
+
+    [self.destroyButton addTarget:self action:@selector(destroyAd) forControlEvents:UIControlEventTouchUpInside];
+
+    [buttonRow addArrangedSubview:leftSpacer];
+    [buttonRow addArrangedSubview:self.loadButton];
+    [buttonRow addArrangedSubview:self.destroyButton];
+    [buttonRow addArrangedSubview:rightSpacer];
+    [self.contentStack addArrangedSubview:buttonRow];
+
+    [NSLayoutConstraint activateConstraints:@[
+        [self.loadButton.widthAnchor constraintEqualToConstant:200],
+        [self.loadButton.heightAnchor constraintEqualToConstant:36],
+        [leftSpacer.widthAnchor constraintEqualToAnchor:rightSpacer.widthAnchor],
+    ]];
+
+    self.bindButton = [UIButton buttonWithType:UIButtonTypeSystem];
+    [self.bindButton setTitle:@"Step 2: Bind & Display" forState:UIControlStateNormal];
+    [self.bindButton setTitleColor:[UIColor whiteColor] forState:UIControlStateNormal];
+    self.bindButton.titleLabel.font = [UIFont boldSystemFontOfSize:14];
+    self.bindButton.backgroundColor = [UIColor systemTealColor];
+    self.bindButton.layer.cornerRadius = 8;
+    self.bindButton.hidden = YES;
+    self.bindButton.alpha = 0;
+    [self.bindButton addTarget:self action:@selector(bindPreloadedAd) forControlEvents:UIControlEventTouchUpInside];
+    [self.contentStack addArrangedSubview:self.bindButton];
+    [self.bindButton.heightAnchor constraintEqualToConstant:36].active = YES;
+
+    self.flowBanner = [[UILabel alloc] init];
+    self.flowBanner.font = [UIFont monospacedSystemFontOfSize:11 weight:UIFontWeightBold];
+    self.flowBanner.textAlignment = NSTextAlignmentCenter;
+    self.flowBanner.numberOfLines = 0;
+    self.flowBanner.textColor = [UIColor secondaryLabelColor];
+    [self.contentStack addArrangedSubview:self.flowBanner];
+
+    self.adContainerView = [[UIView alloc] init];
+    self.adContainerView.clipsToBounds = YES;
+    [self.contentStack addArrangedSubview:self.adContainerView];
+
+    [self.adContainerView.heightAnchor constraintGreaterThanOrEqualToConstant:400].active = YES;
+
+    CGFloat pad = 16;
+    [NSLayoutConstraint activateConstraints:@[
+        [self.scrollView.topAnchor constraintEqualToAnchor:self.view.safeAreaLayoutGuide.topAnchor constant:100],
+        [self.scrollView.leadingAnchor constraintEqualToAnchor:self.view.leadingAnchor],
+        [self.scrollView.trailingAnchor constraintEqualToAnchor:self.view.trailingAnchor],
+        [self.scrollView.bottomAnchor constraintEqualToAnchor:self.statusStack.topAnchor constant:-4],
+
+        [self.contentStack.topAnchor constraintEqualToAnchor:self.scrollView.topAnchor],
+        [self.contentStack.leadingAnchor constraintEqualToAnchor:self.scrollView.leadingAnchor constant:pad],
+        [self.contentStack.trailingAnchor constraintEqualToAnchor:self.scrollView.trailingAnchor constant:-pad],
+        [self.contentStack.bottomAnchor constraintEqualToAnchor:self.scrollView.bottomAnchor constant:-pad],
+        [self.contentStack.widthAnchor constraintEqualToAnchor:self.scrollView.widthAnchor constant:-pad * 2],
+    ]];
+}
+
+- (void)flowPickerChanged {
+    self.activeFlow = (NativeFlow)self.flowPicker.selectedSegmentIndex;
+
+    switch (self.activeFlow) {
+        case NativeFlowTemplate:
+            self.flowDescription.text = @"Template — SDK auto-generates the ad view. Zero custom UI code. Just load and the SDK handles layout.";
+            [self.loadButton setTitle:@"Load Ad" forState:UIControlStateNormal];
+            self.loadButton.backgroundColor = [UIColor systemGreenColor];
+            break;
+        case NativeFlowManual:
+            self.flowDescription.text = @"Manual — Publisher builds a fully custom layout. Every element is positioned and styled by your code.";
+            [self.loadButton setTitle:@"Load Ad" forState:UIControlStateNormal];
+            self.loadButton.backgroundColor = [UIColor systemBlueColor];
+            break;
+        case NativeFlowLateBinding:
+            self.flowDescription.text = @"Late-Bind — Pre-load ad data headlessly, then bind to any custom view on demand. A two-step process.";
+            [self.loadButton setTitle:@"Step 1: Pre-load" forState:UIControlStateNormal];
+            self.loadButton.backgroundColor = [UIColor systemOrangeColor];
+            break;
+    }
+}
+
+#pragma mark - Flow Banner
+
+- (void)updateFlowBannerWithText:(NSString *)text color:(UIColor *)color {
+    self.flowBanner.text = text;
+    self.flowBanner.textColor = color;
+}
+
+- (void)showBindButton:(BOOL)show {
+    if (show && self.bindButton.hidden) {
+        self.bindButton.hidden = NO;
+        [UIView animateWithDuration:0.3 animations:^{
+            self.bindButton.alpha = 1.0;
+        }];
+    } else if (!show && !self.bindButton.hidden) {
+        [UIView animateWithDuration:0.2 animations:^{
+            self.bindButton.alpha = 0;
+        } completion:^(BOOL finished) {
+            self.bindButton.hidden = YES;
+        }];
+    }
+}
+
+#pragma mark - Ad Unit
+
+- (NSString *)adUnitId {
+    NSString *adUnitId = [[CLXDemoConfigManager sharedManager] currentConfig].nativeAdUnitId;
+    if (self.settings.nativeMediumAdUnitId.length > 0) {
+        adUnitId = self.settings.nativeMediumAdUnitId;
+    }
+    return adUnitId;
+}
+
+- (CLXNativeAdLoader *)ensureLoader {
+    if (!self.nativeAdLoader) {
+        self.nativeAdLoader = [[CloudXCore shared] createNativeAdLoaderWithAdUnitIdentifier:[self adUnitId]];
+        self.nativeAdLoader.nativeAdDelegate = self;
+        self.nativeAdLoader.revenueDelegate = self;
+        self.nativeAdLoader.placement = @"demo_native";
+    }
+    return self.nativeAdLoader;
+}
+
+#pragma mark - Load Action
+
+- (void)loadAction {
+    switch (self.activeFlow) {
+        case NativeFlowTemplate:  [self loadTemplate]; break;
+        case NativeFlowManual:    [self loadManual]; break;
+        case NativeFlowLateBinding: [self loadLateBinding]; break;
+    }
+}
+
+#pragma mark - Flow A: Template
+
+- (void)loadTemplate {
+    if (self.isLoading) {
+        [self showAlertWithTitle:@"Info" message:@"Native ad is already loading."];
+        return;
+    }
+    [self resetAdState];
+    self.activeFlow = NativeFlowTemplate;
+    self.isLoading = YES;
+    [self updateStatusUIWithState:AdStateLoading];
+    [self updateFlowBannerWithText:@"Loading template..." color:[UIColor secondaryLabelColor]];
+    [[self ensureLoader] loadAd];
+}
+
+#pragma mark - Flow B: Manual
+
+- (void)loadManual {
+    if (self.isLoading) {
+        [self showAlertWithTitle:@"Info" message:@"Native ad is already loading."];
+        return;
+    }
+    [self resetAdState];
+    self.activeFlow = NativeFlowManual;
+
+    CLXNativeAdView *adView = [self buildManualAdView];
+    CLXNativeAdViewBinder *binder = [[CLXNativeAdViewBinder alloc] initWithBuilderBlock:^(CLXNativeAdViewBinderBuilder *builder) {
+        builder.titleLabelTag = CLXNativeAdViewTagTitleLabel;
+        builder.bodyLabelTag = CLXNativeAdViewTagBodyLabel;
+        builder.callToActionButtonTag = CLXNativeAdViewTagCallToActionButton;
+        builder.iconImageViewTag = CLXNativeAdViewTagIconImageView;
+        builder.mediaContentViewTag = CLXNativeAdViewTagMediaViewContainer;
+        builder.advertiserLabelTag = CLXNativeAdViewTagAdvertiserLabel;
+        builder.optionsContentViewTag = CLXNativeAdViewTagOptionsContentView;
+    }];
+    [adView bindViewsWithViewBinder:binder];
+
+    self.isLoading = YES;
+    [self updateStatusUIWithState:AdStateLoading];
+    [self updateFlowBannerWithText:@"Loading into custom publisher layout..." color:[UIColor secondaryLabelColor]];
+    [[self ensureLoader] loadAdIntoAdView:adView];
+}
+
+#pragma mark - Flow C: Late-Binding (2-step)
+
+- (void)loadLateBinding {
+    if (self.isLoading) {
+        [self showAlertWithTitle:@"Info" message:@"Native ad is already loading."];
+        return;
+    }
+    [self resetAdState];
+    self.activeFlow = NativeFlowLateBinding;
+    self.isLoading = YES;
+    [self updateStatusUIWithState:AdStateLoading];
+    [self updateFlowBannerWithText:@"Step 1: Loading headlessly..." color:[UIColor secondaryLabelColor]];
+    [[self ensureLoader] loadAd];
+}
+
+- (void)bindPreloadedAd {
+    if (!self.preloadedAd) return;
+
+    CLXNativeAdView *spotlightView = [self buildSpotlightAdView];
+    CLXNativeAdViewBinder *binder = [[CLXNativeAdViewBinder alloc] initWithBuilderBlock:^(CLXNativeAdViewBinderBuilder *builder) {
+        builder.titleLabelTag = CLXNativeAdViewTagTitleLabel;
+        builder.bodyLabelTag = CLXNativeAdViewTagBodyLabel;
+        builder.callToActionButtonTag = CLXNativeAdViewTagCallToActionButton;
+        builder.iconImageViewTag = CLXNativeAdViewTagIconImageView;
+        builder.mediaContentViewTag = CLXNativeAdViewTagMediaViewContainer;
+        builder.advertiserLabelTag = CLXNativeAdViewTagAdvertiserLabel;
+        builder.optionsContentViewTag = CLXNativeAdViewTagOptionsContentView;
+    }];
+    [spotlightView bindViewsWithViewBinder:binder];
+    [[self ensureLoader] renderNativeAdView:spotlightView withAd:self.preloadedAd];
+    [self displayAdView:spotlightView];
+
+    self.preloadedAd = nil;
+    [self showBindButton:NO];
+    [self updateFlowBannerWithText:@"COMPLETE — Bound to custom view on demand" color:[UIColor systemGreenColor]];
+    [[DemoAppLogger sharedInstance] logMessage:@"Flow C Step 2: Bound pre-loaded ad to spotlight view"];
+}
+
+#pragma mark - Destroy
+
+- (void)destroyAd {
+    [self resetAdState];
+    [[DemoAppLogger sharedInstance] logMessage:@"Native ad destroyed"];
+}
+
+- (void)resetAdState {
+    if (self.loadedAd) {
+        [self.nativeAdLoader destroyAd:self.loadedAd];
+        self.loadedAd = nil;
+    }
+    if (self.nativeAdView) {
+        [self.nativeAdView removeFromSuperview];
+        self.nativeAdView = nil;
+    }
+    if (self.nativeAdLoader) {
+        [self.nativeAdLoader destroy];
+        self.nativeAdLoader = nil;
+    }
+    self.preloadedAd = nil;
+    self.isLoading = NO;
+    [self showBindButton:NO];
+    [self updateStatusUIWithState:AdStateNoAd];
+    self.flowBanner.text = nil;
+}
+
+#pragma mark - Manual Ad View Builder (media-hero layout)
+
+- (CLXNativeAdView *)buildManualAdView {
+    CLXNativeAdView *adView = [[CLXNativeAdView alloc] init];
+    adView.backgroundColor = [UIColor colorWithRed:0.08 green:0.08 blue:0.10 alpha:1.0];
+    adView.layer.cornerRadius = 16;
+    adView.clipsToBounds = YES;
+
+    UIView *media = [[UIView alloc] init];
+    media.tag = CLXNativeAdViewTagMediaViewContainer;
+    media.clipsToBounds = YES;
+    media.translatesAutoresizingMaskIntoConstraints = NO;
+    [adView addSubview:media];
+
+    UIView *gradient = [[UIView alloc] init];
+    gradient.translatesAutoresizingMaskIntoConstraints = NO;
+    gradient.userInteractionEnabled = NO;
+    [adView addSubview:gradient];
+
+    UIView *options = [[UIView alloc] init];
+    options.tag = CLXNativeAdViewTagOptionsContentView;
+    options.translatesAutoresizingMaskIntoConstraints = NO;
+    [adView addSubview:options];
+
+    UIView *bottomBar = [[UIView alloc] init];
+    bottomBar.translatesAutoresizingMaskIntoConstraints = NO;
+    [adView addSubview:bottomBar];
+
+    UIImageView *icon = [[UIImageView alloc] init];
+    icon.tag = CLXNativeAdViewTagIconImageView;
+    icon.contentMode = UIViewContentModeScaleAspectFill;
+    icon.clipsToBounds = YES;
+    icon.layer.cornerRadius = 22;
+    icon.layer.borderWidth = 2;
+    icon.layer.borderColor = [UIColor whiteColor].CGColor;
+    icon.translatesAutoresizingMaskIntoConstraints = NO;
+    [bottomBar addSubview:icon];
+
+    UILabel *title = [[UILabel alloc] init];
+    title.tag = CLXNativeAdViewTagTitleLabel;
+    title.font = [UIFont boldSystemFontOfSize:15];
+    title.textColor = [UIColor whiteColor];
+    title.translatesAutoresizingMaskIntoConstraints = NO;
+    [bottomBar addSubview:title];
+
+    UILabel *advertiser = [[UILabel alloc] init];
+    advertiser.tag = CLXNativeAdViewTagAdvertiserLabel;
+    advertiser.font = [UIFont systemFontOfSize:10];
+    advertiser.textColor = [UIColor colorWithWhite:1.0 alpha:0.5];
+    advertiser.translatesAutoresizingMaskIntoConstraints = NO;
+    [bottomBar addSubview:advertiser];
+
+    UILabel *body = [[UILabel alloc] init];
+    body.tag = CLXNativeAdViewTagBodyLabel;
+    body.font = [UIFont systemFontOfSize:12];
+    body.textColor = [UIColor colorWithWhite:1.0 alpha:0.7];
+    body.numberOfLines = 1;
+    body.translatesAutoresizingMaskIntoConstraints = NO;
+    [bottomBar addSubview:body];
+
+    UIButton *cta = [UIButton buttonWithType:UIButtonTypeSystem];
+    cta.tag = CLXNativeAdViewTagCallToActionButton;
+    cta.titleLabel.font = [UIFont boldSystemFontOfSize:13];
+    cta.backgroundColor = [UIColor systemGreenColor];
+    [cta setTitleColor:[UIColor whiteColor] forState:UIControlStateNormal];
+    cta.layer.cornerRadius = 16;
+    cta.contentEdgeInsets = UIEdgeInsetsMake(0, 16, 0, 16);
+    cta.translatesAutoresizingMaskIntoConstraints = NO;
+    [bottomBar addSubview:cta];
+
+    [NSLayoutConstraint activateConstraints:@[
+        [media.topAnchor constraintEqualToAnchor:adView.topAnchor],
+        [media.leadingAnchor constraintEqualToAnchor:adView.leadingAnchor],
+        [media.trailingAnchor constraintEqualToAnchor:adView.trailingAnchor],
+        [media.heightAnchor constraintEqualToConstant:300],
+
+        [gradient.leadingAnchor constraintEqualToAnchor:adView.leadingAnchor],
+        [gradient.trailingAnchor constraintEqualToAnchor:adView.trailingAnchor],
+        [gradient.bottomAnchor constraintEqualToAnchor:media.bottomAnchor],
+        [gradient.heightAnchor constraintEqualToConstant:80],
+
+        [options.topAnchor constraintEqualToAnchor:adView.topAnchor constant:8],
+        [options.trailingAnchor constraintEqualToAnchor:adView.trailingAnchor constant:-8],
+        [options.widthAnchor constraintEqualToConstant:28],
+        [options.heightAnchor constraintEqualToConstant:28],
+
+        [bottomBar.topAnchor constraintEqualToAnchor:media.bottomAnchor constant:10],
+        [bottomBar.leadingAnchor constraintEqualToAnchor:adView.leadingAnchor constant:12],
+        [bottomBar.trailingAnchor constraintEqualToAnchor:adView.trailingAnchor constant:-12],
+        [bottomBar.bottomAnchor constraintEqualToAnchor:adView.bottomAnchor constant:-12],
+
+        [icon.topAnchor constraintEqualToAnchor:bottomBar.topAnchor],
+        [icon.leadingAnchor constraintEqualToAnchor:bottomBar.leadingAnchor],
+        [icon.widthAnchor constraintEqualToConstant:44],
+        [icon.heightAnchor constraintEqualToConstant:44],
+
+        [title.topAnchor constraintEqualToAnchor:bottomBar.topAnchor],
+        [title.leadingAnchor constraintEqualToAnchor:icon.trailingAnchor constant:10],
+        [title.trailingAnchor constraintEqualToAnchor:cta.leadingAnchor constant:-8],
+
+        [advertiser.topAnchor constraintEqualToAnchor:title.bottomAnchor constant:1],
+        [advertiser.leadingAnchor constraintEqualToAnchor:title.leadingAnchor],
+
+        [body.topAnchor constraintEqualToAnchor:icon.bottomAnchor constant:8],
+        [body.leadingAnchor constraintEqualToAnchor:bottomBar.leadingAnchor],
+        [body.trailingAnchor constraintEqualToAnchor:bottomBar.trailingAnchor],
+        [body.bottomAnchor constraintEqualToAnchor:bottomBar.bottomAnchor],
+
+        [cta.centerYAnchor constraintEqualToAnchor:icon.centerYAnchor],
+        [cta.trailingAnchor constraintEqualToAnchor:bottomBar.trailingAnchor],
+        [cta.heightAnchor constraintEqualToConstant:32],
+    ]];
+
+    dispatch_async(dispatch_get_main_queue(), ^{
+        CAGradientLayer *grad = [CAGradientLayer layer];
+        grad.colors = @[(id)[UIColor clearColor].CGColor,
+                        (id)[UIColor colorWithRed:0.08 green:0.08 blue:0.10 alpha:0.9].CGColor];
+        grad.frame = gradient.bounds;
+        [gradient.layer insertSublayer:grad atIndex:0];
+
+        [gradient addObserver:self forKeyPath:@"bounds" options:0 context:NULL];
+    });
+
+    return adView;
+}
+
+#pragma mark - Spotlight Ad View Builder (light card for Flow C)
+
+- (CLXNativeAdView *)buildSpotlightAdView {
+    CLXNativeAdView *adView = [[CLXNativeAdView alloc] init];
+    adView.backgroundColor = [UIColor colorWithRed:1.0 green:0.97 blue:0.93 alpha:1.0];
+    adView.layer.cornerRadius = 16;
+    adView.clipsToBounds = YES;
+
+    UIView *header = [[UIView alloc] init];
+    header.translatesAutoresizingMaskIntoConstraints = NO;
+    [adView addSubview:header];
+
+    UIImageView *icon = [[UIImageView alloc] init];
+    icon.tag = CLXNativeAdViewTagIconImageView;
+    icon.contentMode = UIViewContentModeScaleAspectFill;
+    icon.clipsToBounds = YES;
+    icon.layer.cornerRadius = 8;
+    icon.translatesAutoresizingMaskIntoConstraints = NO;
+    [header addSubview:icon];
+
+    UIView *options = [[UIView alloc] init];
+    options.tag = CLXNativeAdViewTagOptionsContentView;
+    options.translatesAutoresizingMaskIntoConstraints = NO;
+    [header addSubview:options];
+
+    UILabel *title = [[UILabel alloc] init];
+    title.tag = CLXNativeAdViewTagTitleLabel;
+    title.font = [UIFont boldSystemFontOfSize:16];
+    title.textColor = [UIColor colorWithRed:0.2 green:0.1 blue:0.0 alpha:1.0];
+    title.translatesAutoresizingMaskIntoConstraints = NO;
+    [header addSubview:title];
+
+    UILabel *advertiser = [[UILabel alloc] init];
+    advertiser.tag = CLXNativeAdViewTagAdvertiserLabel;
+    advertiser.font = [UIFont systemFontOfSize:11];
+    advertiser.textColor = [UIColor colorWithRed:0.6 green:0.4 blue:0.2 alpha:1.0];
+    advertiser.translatesAutoresizingMaskIntoConstraints = NO;
+    [header addSubview:advertiser];
+
+    UILabel *body = [[UILabel alloc] init];
+    body.tag = CLXNativeAdViewTagBodyLabel;
+    body.font = [UIFont systemFontOfSize:13];
+    body.textColor = [UIColor colorWithRed:0.35 green:0.25 blue:0.15 alpha:1.0];
+    body.numberOfLines = 2;
+    body.translatesAutoresizingMaskIntoConstraints = NO;
+    [adView addSubview:body];
+
+    UIView *media = [[UIView alloc] init];
+    media.tag = CLXNativeAdViewTagMediaViewContainer;
+    media.clipsToBounds = YES;
+    media.layer.cornerRadius = 12;
+    media.translatesAutoresizingMaskIntoConstraints = NO;
+    [adView addSubview:media];
+
+    UIButton *cta = [UIButton buttonWithType:UIButtonTypeSystem];
+    cta.tag = CLXNativeAdViewTagCallToActionButton;
+    cta.titleLabel.font = [UIFont boldSystemFontOfSize:15];
+    cta.backgroundColor = [UIColor systemOrangeColor];
+    [cta setTitleColor:[UIColor whiteColor] forState:UIControlStateNormal];
+    cta.layer.cornerRadius = 22;
+    cta.translatesAutoresizingMaskIntoConstraints = NO;
+    [adView addSubview:cta];
+
+    CGFloat pad = 14;
+    [NSLayoutConstraint activateConstraints:@[
+        [header.topAnchor constraintEqualToAnchor:adView.topAnchor constant:pad],
+        [header.leadingAnchor constraintEqualToAnchor:adView.leadingAnchor constant:pad],
+        [header.trailingAnchor constraintEqualToAnchor:adView.trailingAnchor constant:-pad],
+
+        [icon.topAnchor constraintEqualToAnchor:header.topAnchor],
+        [icon.leadingAnchor constraintEqualToAnchor:header.leadingAnchor],
+        [icon.widthAnchor constraintEqualToConstant:44],
+        [icon.heightAnchor constraintEqualToConstant:44],
+        [icon.bottomAnchor constraintEqualToAnchor:header.bottomAnchor],
+
+        [title.topAnchor constraintEqualToAnchor:header.topAnchor constant:2],
+        [title.leadingAnchor constraintEqualToAnchor:icon.trailingAnchor constant:10],
+        [title.trailingAnchor constraintEqualToAnchor:options.leadingAnchor constant:-8],
+
+        [advertiser.topAnchor constraintEqualToAnchor:title.bottomAnchor constant:1],
+        [advertiser.leadingAnchor constraintEqualToAnchor:title.leadingAnchor],
+
+        [options.topAnchor constraintEqualToAnchor:header.topAnchor],
+        [options.trailingAnchor constraintEqualToAnchor:header.trailingAnchor],
+        [options.widthAnchor constraintEqualToConstant:28],
+        [options.heightAnchor constraintEqualToConstant:28],
+
+        [body.topAnchor constraintEqualToAnchor:header.bottomAnchor constant:8],
+        [body.leadingAnchor constraintEqualToAnchor:adView.leadingAnchor constant:pad],
+        [body.trailingAnchor constraintEqualToAnchor:adView.trailingAnchor constant:-pad],
+
+        [media.topAnchor constraintEqualToAnchor:body.bottomAnchor constant:10],
+        [media.leadingAnchor constraintEqualToAnchor:adView.leadingAnchor constant:pad],
+        [media.trailingAnchor constraintEqualToAnchor:adView.trailingAnchor constant:-pad],
+        [media.heightAnchor constraintEqualToConstant:280],
+
+        [cta.topAnchor constraintEqualToAnchor:media.bottomAnchor constant:12],
+        [cta.leadingAnchor constraintEqualToAnchor:adView.leadingAnchor constant:pad],
+        [cta.trailingAnchor constraintEqualToAnchor:adView.trailingAnchor constant:-pad],
+        [cta.heightAnchor constraintEqualToConstant:44],
+        [cta.bottomAnchor constraintEqualToAnchor:adView.bottomAnchor constant:-pad],
+    ]];
+
+    return adView;
+}
+
+- (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context {
+    if ([keyPath isEqualToString:@"bounds"]) {
+        UIView *gradient = object;
+        for (CALayer *layer in gradient.layer.sublayers) {
+            if ([layer isKindOfClass:[CAGradientLayer class]]) {
+                layer.frame = gradient.bounds;
+            }
+        }
+    }
+}
+
+#pragma mark - Display
+
+- (void)displayAdView:(CLXNativeAdView *)adView {
+    [self.nativeAdView removeFromSuperview];
+    self.nativeAdView = adView;
+    adView.translatesAutoresizingMaskIntoConstraints = NO;
+    [self.adContainerView addSubview:adView];
+
+    [NSLayoutConstraint activateConstraints:@[
+        [adView.topAnchor constraintEqualToAnchor:self.adContainerView.topAnchor],
+        [adView.leadingAnchor constraintEqualToAnchor:self.adContainerView.leadingAnchor],
+        [adView.trailingAnchor constraintEqualToAnchor:self.adContainerView.trailingAnchor],
+        [adView.bottomAnchor constraintEqualToAnchor:self.adContainerView.bottomAnchor]
+    ]];
+}
+
+#pragma mark - CLXNativeAdDelegate
+
+- (void)didLoadNativeAd:(nullable CLXNativeAdView *)nativeAdView forAd:(CLXAd *)ad {
+    [[DemoAppLogger sharedInstance] logAdEvent:@"✅ Native didLoadNativeAd" ad:ad];
+    self.isLoading = NO;
+    self.loadedAd = ad;
+
+    if (self.activeFlow == NativeFlowLateBinding) {
+        self.preloadedAd = ad;
+        [self updateStatusUIWithState:AdStateReady];
+        [self updateFlowBannerWithText:@"Step 1 done — tap 'Bind & Display'" color:[UIColor systemOrangeColor]];
+        [self showBindButton:YES];
+        [[DemoAppLogger sharedInstance] logMessage:@"Flow C Step 1: Ad pre-loaded — waiting for bind"];
+        return;
+    }
+
+    [self updateStatusUIWithState:AdStateReady];
+
+    if (nativeAdView) {
+        [self displayAdView:nativeAdView];
+        [self updateFlowBannerWithText:@"MANUAL — Custom publisher layout" color:[UIColor systemBlueColor]];
+    } else {
+        CLXNativeAdView *templateView = [CLXNativeAdView viewFromAd:ad.nativeAd];
+        [[self ensureLoader] renderNativeAdView:templateView withAd:ad];
+        [self displayAdView:templateView];
+        [self updateFlowBannerWithText:@"TEMPLATE — SDK auto-generated view" color:[UIColor systemGreenColor]];
+    }
+}
+
+- (void)didFailToLoadNativeAdForAdUnitIdentifier:(NSString *)adUnitId error:(CLXError *)error {
+    [[DemoAppLogger sharedInstance] logMessage:[NSString stringWithFormat:@"❌ Native failed (%@) - %@", adUnitId, error.localizedDescription]];
+    self.isLoading = NO;
+    [self updateStatusUIWithState:AdStateNoAd];
+    self.flowBanner.text = nil;
+
+    dispatch_async(dispatch_get_main_queue(), ^{
+        NSString *msg = error ? [error detailedDemoDescription] : @"Unknown error";
+        [self showAlertWithTitle:@"Native Load Failed" message:msg];
+    });
+}
+
+- (void)didClickNativeAd:(CLXAd *)ad {
+    [[DemoAppLogger sharedInstance] logAdEvent:@"👆 Native didClickNativeAd" ad:ad];
+}
+
+- (void)didExpireNativeAd:(CLXAd *)ad {
+    [[DemoAppLogger sharedInstance] logAdEvent:@"⏰ Native didExpireNativeAd" ad:ad];
+    [self resetAdState];
+}
+
+- (void)didCloseNativeAd:(CLXAd *)ad {
+    [[DemoAppLogger sharedInstance] logAdEvent:@"🚪 Native didCloseNativeAd — user reported/hid ad via AdChoices" ad:ad];
+}
+
+#pragma mark - CLXAdRevenueDelegate
+
+- (void)didPayRevenueForAd:(CLXAd *)ad {
+    [[DemoAppLogger sharedInstance] logAdEvent:@"💰 Native didPayRevenueForAd" ad:ad];
+}
+
+- (void)updateStatusUIWithState:(AdState)state {
+    self.adState = state;
+    [super updateStatusUIWithState:state];
+}
+
+@end

--- a/demo-app-objc/CloudXObjCRemotePods/Views/Ad/ReelsFeedViewController.h
+++ b/demo-app-objc/CloudXObjCRemotePods/Views/Ad/ReelsFeedViewController.h
@@ -1,0 +1,9 @@
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface ReelsFeedViewController : UIViewController
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/demo-app-objc/CloudXObjCRemotePods/Views/Ad/ReelsFeedViewController.m
+++ b/demo-app-objc/CloudXObjCRemotePods/Views/Ad/ReelsFeedViewController.m
@@ -1,0 +1,804 @@
+#import "ReelsFeedViewController.h"
+#import <CloudXCore/CloudXCore.h>
+#import "CLXDemoConfigManager.h"
+#import "DemoAppLogger.h"
+#import "LogsModalViewController.h"
+#import "UserDefaultsSettings.h"
+
+static const NSInteger kReelsAdCount = 5;
+static NSString * const kReelsCellIdentifier = @"ReelsCell";
+
+#pragma mark - ReelsAdItem
+
+@interface ReelsAdItem : NSObject
+@property (nonatomic, strong, nullable) CLXNativeAdLoader *loader;
+@property (nonatomic, strong, nullable) CLXAd *ad;
+@property (nonatomic, strong, nullable) CLXNativeAd *nativeAd;
+@property (nonatomic, assign) BOOL isLoading;
+@property (nonatomic, assign) BOOL isLoaded;
+@property (nonatomic, assign) BOOL isFailed;
+@property (nonatomic, assign) BOOL hideControls;
+@property (nonatomic, assign) BOOL isImagePlaceholder;
+@end
+
+@implementation ReelsAdItem
+@end
+
+#pragma mark - ReelsCell
+
+@interface ReelsCell : UICollectionViewCell
+@property (nonatomic, strong) CLXNativeAdView *nativeAdView;
+@property (nonatomic, strong) UIView *mediaContainer;
+@property (nonatomic, strong) UIView *gradientContainer;
+@property (nonatomic, strong) UILabel *titleLabel;
+@property (nonatomic, strong) UILabel *bodyLabel;
+@property (nonatomic, strong) UILabel *advertiserLabel;
+@property (nonatomic, strong) UIButton *ctaButton;
+@property (nonatomic, strong) UIView *optionsContainer;
+@property (nonatomic, strong) UIView *iconContainer;
+@property (nonatomic, strong) UIImageView *iconImageView;
+@property (nonatomic, strong) UIActivityIndicatorView *spinner;
+@property (nonatomic, strong) UILabel *slotLabel;
+@property (nonatomic, strong) UILabel *videoBadge;
+@property (nonatomic, strong) UILabel *durationLabel;
+@property (nonatomic, strong) UIImageView *placeholderImageView;
+@property (nonatomic, strong, nullable) CAGradientLayer *gradient;
+@end
+
+@implementation ReelsCell
+
+- (instancetype)initWithFrame:(CGRect)frame {
+    self = [super initWithFrame:frame];
+    if (self) {
+        self.contentView.backgroundColor = [UIColor blackColor];
+        self.contentView.clipsToBounds = YES;
+        [self buildSubviews];
+    }
+    return self;
+}
+
+- (void)buildSubviews {
+    self.nativeAdView = [[CLXNativeAdView alloc] init];
+    self.nativeAdView.translatesAutoresizingMaskIntoConstraints = NO;
+    self.nativeAdView.backgroundColor = [UIColor clearColor];
+    [self.contentView addSubview:self.nativeAdView];
+
+    self.mediaContainer = [[UIView alloc] init];
+    self.mediaContainer.translatesAutoresizingMaskIntoConstraints = NO;
+    self.mediaContainer.clipsToBounds = YES;
+    [self.nativeAdView addSubview:self.mediaContainer];
+
+    self.gradientContainer = [[UIView alloc] init];
+    self.gradientContainer.translatesAutoresizingMaskIntoConstraints = NO;
+    self.gradientContainer.userInteractionEnabled = NO;
+    [self.nativeAdView addSubview:self.gradientContainer];
+
+    self.iconContainer = [[UIView alloc] init];
+    self.iconContainer.translatesAutoresizingMaskIntoConstraints = NO;
+    self.iconContainer.clipsToBounds = YES;
+    self.iconContainer.layer.cornerRadius = 20;
+    [self.nativeAdView addSubview:self.iconContainer];
+
+    self.iconImageView = [[UIImageView alloc] init];
+    self.iconImageView.contentMode = UIViewContentModeScaleAspectFill;
+    self.iconImageView.clipsToBounds = YES;
+    self.iconImageView.translatesAutoresizingMaskIntoConstraints = NO;
+    [self.iconContainer addSubview:self.iconImageView];
+
+    self.titleLabel = [[UILabel alloc] init];
+    self.titleLabel.font = [UIFont boldSystemFontOfSize:17];
+    self.titleLabel.textColor = [UIColor whiteColor];
+    self.titleLabel.numberOfLines = 2;
+    self.titleLabel.translatesAutoresizingMaskIntoConstraints = NO;
+    [self.nativeAdView addSubview:self.titleLabel];
+
+    self.advertiserLabel = [[UILabel alloc] init];
+    self.advertiserLabel.font = [UIFont systemFontOfSize:13];
+    self.advertiserLabel.textColor = [UIColor colorWithWhite:1.0 alpha:0.7];
+    self.advertiserLabel.translatesAutoresizingMaskIntoConstraints = NO;
+    [self.nativeAdView addSubview:self.advertiserLabel];
+
+    self.bodyLabel = [[UILabel alloc] init];
+    self.bodyLabel.font = [UIFont systemFontOfSize:14];
+    self.bodyLabel.textColor = [UIColor colorWithWhite:1.0 alpha:0.9];
+    self.bodyLabel.numberOfLines = 2;
+    self.bodyLabel.translatesAutoresizingMaskIntoConstraints = NO;
+    [self.nativeAdView addSubview:self.bodyLabel];
+
+    self.ctaButton = [UIButton buttonWithType:UIButtonTypeSystem];
+    self.ctaButton.titleLabel.font = [UIFont boldSystemFontOfSize:15];
+    self.ctaButton.backgroundColor = [UIColor whiteColor];
+    [self.ctaButton setTitleColor:[UIColor blackColor] forState:UIControlStateNormal];
+    self.ctaButton.layer.cornerRadius = 22;
+    self.ctaButton.translatesAutoresizingMaskIntoConstraints = NO;
+    [self.nativeAdView addSubview:self.ctaButton];
+
+    self.optionsContainer = [[UIView alloc] init];
+    self.optionsContainer.translatesAutoresizingMaskIntoConstraints = NO;
+    [self.nativeAdView addSubview:self.optionsContainer];
+
+    self.spinner = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleLarge];
+    self.spinner.color = [UIColor whiteColor];
+    self.spinner.translatesAutoresizingMaskIntoConstraints = NO;
+    self.spinner.hidesWhenStopped = YES;
+    [self.nativeAdView addSubview:self.spinner];
+
+    self.slotLabel = [[UILabel alloc] init];
+    self.slotLabel.font = [UIFont monospacedSystemFontOfSize:11 weight:UIFontWeightMedium];
+    self.slotLabel.textColor = [UIColor colorWithWhite:1.0 alpha:0.5];
+    self.slotLabel.translatesAutoresizingMaskIntoConstraints = NO;
+    [self.nativeAdView addSubview:self.slotLabel];
+
+    self.videoBadge = [[UILabel alloc] init];
+    self.videoBadge.font = [UIFont monospacedSystemFontOfSize:10 weight:UIFontWeightBold];
+    self.videoBadge.textColor = [UIColor whiteColor];
+    self.videoBadge.textAlignment = NSTextAlignmentCenter;
+    self.videoBadge.layer.cornerRadius = 4;
+    self.videoBadge.clipsToBounds = YES;
+    self.videoBadge.translatesAutoresizingMaskIntoConstraints = NO;
+    self.videoBadge.hidden = YES;
+    [self.nativeAdView addSubview:self.videoBadge];
+
+    self.durationLabel = [[UILabel alloc] init];
+    self.durationLabel.font = [UIFont monospacedDigitSystemFontOfSize:13 weight:UIFontWeightSemibold];
+    self.durationLabel.textColor = [UIColor whiteColor];
+    self.durationLabel.textAlignment = NSTextAlignmentCenter;
+    self.durationLabel.backgroundColor = [[UIColor blackColor] colorWithAlphaComponent:0.6];
+    self.durationLabel.layer.cornerRadius = 4;
+    self.durationLabel.clipsToBounds = YES;
+    self.durationLabel.translatesAutoresizingMaskIntoConstraints = NO;
+    self.durationLabel.hidden = YES;
+    [self.nativeAdView addSubview:self.durationLabel];
+
+    self.placeholderImageView = [[UIImageView alloc] init];
+    self.placeholderImageView.contentMode = UIViewContentModeScaleAspectFill;
+    self.placeholderImageView.clipsToBounds = YES;
+    self.placeholderImageView.translatesAutoresizingMaskIntoConstraints = NO;
+    self.placeholderImageView.hidden = YES;
+    [self.nativeAdView insertSubview:self.placeholderImageView aboveSubview:self.mediaContainer];
+
+    self.nativeAdView.mediaContentView = self.mediaContainer;
+    self.nativeAdView.callToActionButton = self.ctaButton;
+    self.nativeAdView.titleLabel = self.titleLabel;
+    self.nativeAdView.bodyLabel = self.bodyLabel;
+    self.nativeAdView.advertiserLabel = self.advertiserLabel;
+    self.nativeAdView.optionsContentView = self.optionsContainer;
+    self.nativeAdView.iconContentView = self.iconContainer;
+    self.nativeAdView.iconImageView = self.iconImageView;
+
+    CGFloat pad = 16;
+    [NSLayoutConstraint activateConstraints:@[
+        [self.nativeAdView.topAnchor constraintEqualToAnchor:self.contentView.topAnchor],
+        [self.nativeAdView.leadingAnchor constraintEqualToAnchor:self.contentView.leadingAnchor],
+        [self.nativeAdView.trailingAnchor constraintEqualToAnchor:self.contentView.trailingAnchor],
+        [self.nativeAdView.bottomAnchor constraintEqualToAnchor:self.contentView.bottomAnchor],
+
+        [self.mediaContainer.topAnchor constraintEqualToAnchor:self.nativeAdView.topAnchor],
+        [self.mediaContainer.leadingAnchor constraintEqualToAnchor:self.nativeAdView.leadingAnchor],
+        [self.mediaContainer.trailingAnchor constraintEqualToAnchor:self.nativeAdView.trailingAnchor],
+        [self.mediaContainer.bottomAnchor constraintEqualToAnchor:self.nativeAdView.bottomAnchor],
+
+        [self.gradientContainer.leadingAnchor constraintEqualToAnchor:self.nativeAdView.leadingAnchor],
+        [self.gradientContainer.trailingAnchor constraintEqualToAnchor:self.nativeAdView.trailingAnchor],
+        [self.gradientContainer.bottomAnchor constraintEqualToAnchor:self.nativeAdView.bottomAnchor],
+        [self.gradientContainer.heightAnchor constraintEqualToConstant:280],
+
+        [self.ctaButton.leadingAnchor constraintEqualToAnchor:self.nativeAdView.leadingAnchor constant:pad],
+        [self.ctaButton.trailingAnchor constraintEqualToAnchor:self.nativeAdView.trailingAnchor constant:-pad],
+        [self.ctaButton.bottomAnchor constraintEqualToAnchor:self.nativeAdView.safeAreaLayoutGuide.bottomAnchor constant:-pad],
+        [self.ctaButton.heightAnchor constraintEqualToConstant:44],
+
+        [self.bodyLabel.leadingAnchor constraintEqualToAnchor:self.nativeAdView.leadingAnchor constant:pad],
+        [self.bodyLabel.trailingAnchor constraintEqualToAnchor:self.nativeAdView.trailingAnchor constant:-pad],
+        [self.bodyLabel.bottomAnchor constraintEqualToAnchor:self.ctaButton.topAnchor constant:-12],
+
+        [self.iconContainer.leadingAnchor constraintEqualToAnchor:self.nativeAdView.leadingAnchor constant:pad],
+        [self.iconContainer.widthAnchor constraintEqualToConstant:40],
+        [self.iconContainer.heightAnchor constraintEqualToConstant:40],
+        [self.iconContainer.bottomAnchor constraintEqualToAnchor:self.bodyLabel.topAnchor constant:-10],
+
+        [self.iconImageView.topAnchor constraintEqualToAnchor:self.iconContainer.topAnchor],
+        [self.iconImageView.leadingAnchor constraintEqualToAnchor:self.iconContainer.leadingAnchor],
+        [self.iconImageView.trailingAnchor constraintEqualToAnchor:self.iconContainer.trailingAnchor],
+        [self.iconImageView.bottomAnchor constraintEqualToAnchor:self.iconContainer.bottomAnchor],
+
+        [self.titleLabel.leadingAnchor constraintEqualToAnchor:self.iconContainer.trailingAnchor constant:10],
+        [self.titleLabel.trailingAnchor constraintEqualToAnchor:self.nativeAdView.trailingAnchor constant:-pad],
+        [self.titleLabel.centerYAnchor constraintEqualToAnchor:self.iconContainer.centerYAnchor constant:-8],
+
+        [self.advertiserLabel.leadingAnchor constraintEqualToAnchor:self.titleLabel.leadingAnchor],
+        [self.advertiserLabel.trailingAnchor constraintEqualToAnchor:self.titleLabel.trailingAnchor],
+        [self.advertiserLabel.topAnchor constraintEqualToAnchor:self.titleLabel.bottomAnchor constant:2],
+
+        [self.optionsContainer.topAnchor constraintEqualToAnchor:self.nativeAdView.safeAreaLayoutGuide.topAnchor constant:8],
+        [self.optionsContainer.trailingAnchor constraintEqualToAnchor:self.nativeAdView.trailingAnchor constant:-pad],
+        [self.optionsContainer.widthAnchor constraintEqualToConstant:30],
+        [self.optionsContainer.heightAnchor constraintEqualToConstant:30],
+
+        [self.spinner.centerXAnchor constraintEqualToAnchor:self.nativeAdView.centerXAnchor],
+        [self.spinner.centerYAnchor constraintEqualToAnchor:self.nativeAdView.centerYAnchor],
+
+        [self.slotLabel.topAnchor constraintEqualToAnchor:self.nativeAdView.safeAreaLayoutGuide.topAnchor constant:8],
+        [self.slotLabel.leadingAnchor constraintEqualToAnchor:self.nativeAdView.leadingAnchor constant:pad],
+
+        [self.videoBadge.leadingAnchor constraintEqualToAnchor:self.slotLabel.trailingAnchor constant:8],
+        [self.videoBadge.centerYAnchor constraintEqualToAnchor:self.slotLabel.centerYAnchor],
+        [self.videoBadge.heightAnchor constraintEqualToConstant:18],
+
+        [self.durationLabel.trailingAnchor constraintEqualToAnchor:self.nativeAdView.trailingAnchor constant:-pad],
+        [self.durationLabel.bottomAnchor constraintEqualToAnchor:self.iconContainer.topAnchor constant:-16],
+        [self.durationLabel.heightAnchor constraintEqualToConstant:24],
+
+        [self.placeholderImageView.topAnchor constraintEqualToAnchor:self.nativeAdView.topAnchor],
+        [self.placeholderImageView.leadingAnchor constraintEqualToAnchor:self.nativeAdView.leadingAnchor],
+        [self.placeholderImageView.trailingAnchor constraintEqualToAnchor:self.nativeAdView.trailingAnchor],
+        [self.placeholderImageView.bottomAnchor constraintEqualToAnchor:self.nativeAdView.bottomAnchor],
+    ]];
+}
+
+- (void)layoutSubviews {
+    [super layoutSubviews];
+    if (!self.gradient) {
+        self.gradient = [CAGradientLayer layer];
+        self.gradient.colors = @[
+            (id)[UIColor clearColor].CGColor,
+            (id)[UIColor colorWithWhite:0 alpha:0.8].CGColor,
+        ];
+        self.gradient.locations = @[@0.0, @1.0];
+        [self.gradientContainer.layer insertSublayer:self.gradient atIndex:0];
+    }
+    self.gradient.frame = self.gradientContainer.bounds;
+}
+
+- (void)configureWithItem:(ReelsAdItem *)item atIndex:(NSInteger)index {
+    self.slotLabel.text = [NSString stringWithFormat:@"%ld / %ld", (long)(index + 1), (long)kReelsAdCount];
+
+    if (item.isImagePlaceholder) {
+        [self.spinner stopAnimating];
+        self.placeholderImageView.hidden = NO;
+        self.placeholderImageView.image = [UIImage systemImageNamed:@"photo.artframe"];
+        self.placeholderImageView.tintColor = [UIColor colorWithWhite:1.0 alpha:0.15];
+        self.placeholderImageView.contentMode = UIViewContentModeScaleAspectFit;
+        self.mediaContainer.hidden = YES;
+        [self showOverlayUI:YES];
+        self.titleLabel.text = @"Sample Static Ad";
+        self.bodyLabel.text = @"This reel demonstrates the IMAGE badge path";
+        self.advertiserLabel.text = @"Demo Advertiser";
+        [self.ctaButton setTitle:@"Learn More" forState:UIControlStateNormal];
+        self.videoBadge.hidden = NO;
+        self.videoBadge.text = @" IMAGE ";
+        self.videoBadge.backgroundColor = [[UIColor systemBlueColor] colorWithAlphaComponent:0.7];
+        self.durationLabel.hidden = YES;
+    } else if (item.isLoaded && item.nativeAd) {
+        [self.spinner stopAnimating];
+        self.placeholderImageView.hidden = YES;
+        self.mediaContainer.hidden = NO;
+        [self showOverlayUI:!item.hideControls];
+        [self updateVideoBadgeWithNativeAd:item.nativeAd];
+    } else if (item.isFailed) {
+        [self.spinner stopAnimating];
+        self.placeholderImageView.hidden = YES;
+        self.mediaContainer.hidden = NO;
+        [self showOverlayUI:NO];
+        self.titleLabel.text = @"Load Failed";
+        self.titleLabel.hidden = NO;
+        self.bodyLabel.hidden = YES;
+        self.videoBadge.hidden = YES;
+        self.durationLabel.hidden = YES;
+    } else {
+        [self.spinner startAnimating];
+        self.placeholderImageView.hidden = YES;
+        self.mediaContainer.hidden = NO;
+        [self showOverlayUI:NO];
+        self.videoBadge.hidden = YES;
+        self.durationLabel.hidden = YES;
+    }
+}
+
+- (void)updateVideoBadgeWithNativeAd:(CLXNativeAd *)nativeAd {
+    self.videoBadge.hidden = NO;
+    if (nativeAd.isVideoContent) {
+        self.videoBadge.text = @" VIDEO ";
+        self.videoBadge.backgroundColor = [[UIColor systemRedColor] colorWithAlphaComponent:0.85];
+
+        if (nativeAd.videoDuration > 0) {
+            NSInteger totalSeconds = (NSInteger)nativeAd.videoDuration;
+            NSInteger minutes = totalSeconds / 60;
+            NSInteger seconds = totalSeconds % 60;
+            self.durationLabel.text = [NSString stringWithFormat:@" %ld:%02ld ", (long)minutes, (long)seconds];
+            self.durationLabel.hidden = NO;
+        } else {
+            self.durationLabel.hidden = YES;
+        }
+    } else {
+        self.videoBadge.text = @" STATIC ";
+        self.videoBadge.backgroundColor = [[UIColor systemBlueColor] colorWithAlphaComponent:0.7];
+        self.durationLabel.hidden = YES;
+    }
+}
+
+- (void)showOverlayUI:(BOOL)show {
+    self.titleLabel.hidden = !show;
+    self.advertiserLabel.hidden = !show;
+    self.bodyLabel.hidden = !show;
+    self.ctaButton.hidden = !show;
+    self.gradientContainer.hidden = !show;
+    self.iconContainer.hidden = !show;
+}
+
+- (void)prepareForReuse {
+    [super prepareForReuse];
+    [self.spinner stopAnimating];
+    [self.nativeAdView prepareForReuse];
+    [self.iconContainer addSubview:self.iconImageView];
+    self.iconImageView.image = nil;
+    self.videoBadge.hidden = YES;
+    self.durationLabel.hidden = YES;
+    self.placeholderImageView.hidden = YES;
+    self.placeholderImageView.image = nil;
+    self.mediaContainer.hidden = NO;
+}
+
+@end
+
+#pragma mark - ReelsFeedViewController
+
+@interface ReelsFeedViewController () <UICollectionViewDataSource, UICollectionViewDelegateFlowLayout, CLXNativeAdDelegate, CLXAdRevenueDelegate>
+@property (nonatomic, strong) UICollectionView *collectionView;
+@property (nonatomic, strong) NSMutableArray<ReelsAdItem *> *items;
+@property (nonatomic, assign) NSInteger nextLoadIndex;
+@property (nonatomic, strong) UIView *settingsPanel;
+@property (nonatomic, strong) UISwitch *fullScreenSwitch;
+@property (nonatomic, strong) UISwitch *unmutedSwitch;
+@property (nonatomic, strong) UISwitch *hideControlsSwitch;
+@property (nonatomic, assign) BOOL settingsPanelVisible;
+@property (nonatomic, strong) UIButton *gearButton;
+@property (nonatomic, strong) UIStackView *settingsBadgesStack;
+@end
+
+@implementation ReelsFeedViewController
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    self.title = @"Reels Feed";
+    self.view.backgroundColor = [UIColor blackColor];
+
+    [self setupCollectionView];
+    [self setupAppLogsButton];
+    [self setupSettingsPanel];
+    [self createItems];
+    [self loadNextAd];
+}
+
+- (void)dealloc {
+    for (ReelsAdItem *item in self.items) {
+        [item.loader destroy];
+    }
+}
+
+- (UIStatusBarStyle)preferredStatusBarStyle {
+    return UIStatusBarStyleLightContent;
+}
+
+#pragma mark - Setup
+
+- (void)setupCollectionView {
+    UICollectionViewFlowLayout *layout = [[UICollectionViewFlowLayout alloc] init];
+    layout.scrollDirection = UICollectionViewScrollDirectionVertical;
+    layout.minimumLineSpacing = 0;
+    layout.minimumInteritemSpacing = 0;
+
+    self.collectionView = [[UICollectionView alloc] initWithFrame:CGRectZero collectionViewLayout:layout];
+    self.collectionView.translatesAutoresizingMaskIntoConstraints = NO;
+    self.collectionView.dataSource = self;
+    self.collectionView.delegate = self;
+    self.collectionView.pagingEnabled = YES;
+    self.collectionView.showsVerticalScrollIndicator = NO;
+    self.collectionView.backgroundColor = [UIColor blackColor];
+    self.collectionView.contentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentNever;
+    [self.collectionView registerClass:[ReelsCell class] forCellWithReuseIdentifier:kReelsCellIdentifier];
+    [self.view addSubview:self.collectionView];
+
+    [NSLayoutConstraint activateConstraints:@[
+        [self.collectionView.topAnchor constraintEqualToAnchor:self.view.topAnchor],
+        [self.collectionView.leadingAnchor constraintEqualToAnchor:self.view.leadingAnchor],
+        [self.collectionView.trailingAnchor constraintEqualToAnchor:self.view.trailingAnchor],
+        [self.collectionView.bottomAnchor constraintEqualToAnchor:self.view.bottomAnchor],
+    ]];
+}
+
+- (void)setupAppLogsButton {
+    UIButton *logsButton = [UIButton buttonWithType:UIButtonTypeSystem];
+    [logsButton setTitle:@"App Logs" forState:UIControlStateNormal];
+    logsButton.titleLabel.font = [UIFont systemFontOfSize:14 weight:UIFontWeightMedium];
+    logsButton.backgroundColor = [[UIColor systemOrangeColor] colorWithAlphaComponent:0.9];
+    [logsButton setTitleColor:[UIColor whiteColor] forState:UIControlStateNormal];
+    logsButton.layer.cornerRadius = 6;
+    logsButton.translatesAutoresizingMaskIntoConstraints = NO;
+    [logsButton addTarget:self action:@selector(showLogsModal) forControlEvents:UIControlEventTouchUpInside];
+    [self.view addSubview:logsButton];
+
+    [NSLayoutConstraint activateConstraints:@[
+        [logsButton.topAnchor constraintEqualToAnchor:self.view.safeAreaLayoutGuide.topAnchor constant:8],
+        [logsButton.trailingAnchor constraintEqualToAnchor:self.view.trailingAnchor constant:-12],
+        [logsButton.widthAnchor constraintEqualToConstant:90],
+        [logsButton.heightAnchor constraintEqualToConstant:30],
+    ]];
+}
+
+- (void)showLogsModal {
+    LogsModalViewController *logsModal = [[LogsModalViewController alloc] initWithTitle:@"Logs"];
+    logsModal.modalPresentationStyle = UIModalPresentationPageSheet;
+    [self presentViewController:logsModal animated:YES completion:nil];
+}
+
+- (void)setupSettingsPanel {
+    self.gearButton = [UIButton buttonWithType:UIButtonTypeSystem];
+    UIImageSymbolConfiguration *iconConfig = [UIImageSymbolConfiguration configurationWithPointSize:12 weight:UIImageSymbolWeightMedium];
+    UIImage *gearIcon = [UIImage systemImageNamed:@"slider.horizontal.3" withConfiguration:iconConfig];
+    [self.gearButton setImage:gearIcon forState:UIControlStateNormal];
+    [self.gearButton setTitle:@" Video Config" forState:UIControlStateNormal];
+    self.gearButton.titleLabel.font = [UIFont systemFontOfSize:12 weight:UIFontWeightSemibold];
+    self.gearButton.tintColor = [UIColor whiteColor];
+    self.gearButton.backgroundColor = [[UIColor blackColor] colorWithAlphaComponent:0.6];
+    self.gearButton.layer.cornerRadius = 14;
+    self.gearButton.contentEdgeInsets = UIEdgeInsetsMake(6, 10, 6, 12);
+    self.gearButton.translatesAutoresizingMaskIntoConstraints = NO;
+    [self.gearButton addTarget:self action:@selector(toggleSettingsPanel) forControlEvents:UIControlEventTouchUpInside];
+    [self.view addSubview:self.gearButton];
+
+    self.settingsBadgesStack = [[UIStackView alloc] init];
+    self.settingsBadgesStack.axis = UILayoutConstraintAxisHorizontal;
+    self.settingsBadgesStack.spacing = 4;
+    self.settingsBadgesStack.translatesAutoresizingMaskIntoConstraints = NO;
+    [self.view addSubview:self.settingsBadgesStack];
+
+    UIVisualEffectView *blurView = [[UIVisualEffectView alloc] initWithEffect:[UIBlurEffect effectWithStyle:UIBlurEffectStyleDark]];
+    blurView.layer.cornerRadius = 12;
+    blurView.clipsToBounds = YES;
+    blurView.translatesAutoresizingMaskIntoConstraints = NO;
+
+    self.settingsPanel = [[UIView alloc] init];
+    self.settingsPanel.translatesAutoresizingMaskIntoConstraints = NO;
+    self.settingsPanel.alpha = 0;
+    self.settingsPanel.hidden = YES;
+    [self.view addSubview:self.settingsPanel];
+    [self.settingsPanel addSubview:blurView];
+
+    [NSLayoutConstraint activateConstraints:@[
+        [blurView.topAnchor constraintEqualToAnchor:self.settingsPanel.topAnchor],
+        [blurView.leadingAnchor constraintEqualToAnchor:self.settingsPanel.leadingAnchor],
+        [blurView.trailingAnchor constraintEqualToAnchor:self.settingsPanel.trailingAnchor],
+        [blurView.bottomAnchor constraintEqualToAnchor:self.settingsPanel.bottomAnchor],
+    ]];
+
+    UILabel *header = [[UILabel alloc] init];
+    header.text = @"Video Config";
+    header.font = [UIFont boldSystemFontOfSize:14];
+    header.textColor = [UIColor whiteColor];
+
+    self.fullScreenSwitch = [[UISwitch alloc] init];
+    self.fullScreenSwitch.on = YES;
+    self.fullScreenSwitch.transform = CGAffineTransformMakeScale(0.7, 0.7);
+
+    self.unmutedSwitch = [[UISwitch alloc] init];
+    self.unmutedSwitch.on = YES;
+    self.unmutedSwitch.transform = CGAffineTransformMakeScale(0.7, 0.7);
+
+    self.hideControlsSwitch = [[UISwitch alloc] init];
+    self.hideControlsSwitch.on = YES;
+    self.hideControlsSwitch.transform = CGAffineTransformMakeScale(0.7, 0.7);
+
+    UIButton *reloadButton = [UIButton buttonWithType:UIButtonTypeSystem];
+    [reloadButton setTitle:@"Reload Ads" forState:UIControlStateNormal];
+    reloadButton.titleLabel.font = [UIFont boldSystemFontOfSize:13];
+    reloadButton.backgroundColor = [UIColor systemBlueColor];
+    [reloadButton setTitleColor:[UIColor whiteColor] forState:UIControlStateNormal];
+    reloadButton.layer.cornerRadius = 8;
+    reloadButton.translatesAutoresizingMaskIntoConstraints = NO;
+    [reloadButton addTarget:self action:@selector(reloadAdsWithSettings) forControlEvents:UIControlEventTouchUpInside];
+    [reloadButton.heightAnchor constraintEqualToConstant:32].active = YES;
+
+    UILabel *disclaimer = [[UILabel alloc] init];
+    disclaimer.text = @"Requires FAN SDK 6.21.1+ for Meta native ads";
+    disclaimer.font = [UIFont italicSystemFontOfSize:9];
+    disclaimer.textColor = [UIColor colorWithWhite:1.0 alpha:0.45];
+    disclaimer.numberOfLines = 0;
+    disclaimer.textAlignment = NSTextAlignmentCenter;
+
+    UIStackView *stack = [[UIStackView alloc] initWithArrangedSubviews:@[
+        header,
+        [self settingsRowWithLabel:@"Disable Fullscreen" toggle:self.fullScreenSwitch],
+        [self settingsRowWithLabel:@"Start Unmuted" toggle:self.unmutedSwitch],
+        [self settingsRowWithLabel:@"Hide Controls" toggle:self.hideControlsSwitch],
+        reloadButton,
+        disclaimer
+    ]];
+    stack.axis = UILayoutConstraintAxisVertical;
+    stack.spacing = 8;
+    stack.translatesAutoresizingMaskIntoConstraints = NO;
+    [self.settingsPanel addSubview:stack];
+
+    [NSLayoutConstraint activateConstraints:@[
+        [self.gearButton.topAnchor constraintEqualToAnchor:self.view.safeAreaLayoutGuide.topAnchor constant:44],
+        [self.gearButton.trailingAnchor constraintEqualToAnchor:self.view.trailingAnchor constant:-12],
+        [self.gearButton.heightAnchor constraintEqualToConstant:28],
+
+        [self.settingsBadgesStack.topAnchor constraintEqualToAnchor:self.gearButton.bottomAnchor constant:6],
+        [self.settingsBadgesStack.trailingAnchor constraintEqualToAnchor:self.view.trailingAnchor constant:-12],
+
+        [self.settingsPanel.topAnchor constraintEqualToAnchor:self.settingsBadgesStack.bottomAnchor constant:6],
+        [self.settingsPanel.trailingAnchor constraintEqualToAnchor:self.view.trailingAnchor constant:-12],
+        [self.settingsPanel.widthAnchor constraintEqualToConstant:220],
+        [stack.topAnchor constraintEqualToAnchor:self.settingsPanel.topAnchor constant:12],
+        [stack.leadingAnchor constraintEqualToAnchor:self.settingsPanel.leadingAnchor constant:12],
+        [stack.trailingAnchor constraintEqualToAnchor:self.settingsPanel.trailingAnchor constant:-12],
+        [stack.bottomAnchor constraintEqualToAnchor:self.settingsPanel.bottomAnchor constant:-12],
+    ]];
+
+    [self updateSettingsBadges];
+}
+
+- (UIStackView *)settingsRowWithLabel:(NSString *)text toggle:(UISwitch *)toggle {
+    UILabel *label = [[UILabel alloc] init];
+    label.text = text;
+    label.font = [UIFont systemFontOfSize:12 weight:UIFontWeightMedium];
+    label.textColor = [UIColor colorWithWhite:1.0 alpha:0.9];
+    UIStackView *row = [[UIStackView alloc] initWithArrangedSubviews:@[label, toggle]];
+    row.axis = UILayoutConstraintAxisHorizontal;
+    row.alignment = UIStackViewAlignmentCenter;
+    row.distribution = UIStackViewDistributionEqualSpacing;
+    return row;
+}
+
+- (void)updateSettingsBadges {
+    for (UIView *v in self.settingsBadgesStack.arrangedSubviews) { [v removeFromSuperview]; }
+
+    BOOL disableFS = self.fullScreenSwitch ? self.fullScreenSwitch.isOn : YES;
+    BOOL unmuted   = self.unmutedSwitch ? self.unmutedSwitch.isOn : YES;
+    BOOL hideCtrl  = self.hideControlsSwitch ? self.hideControlsSwitch.isOn : YES;
+
+    if (disableFS)  [self.settingsBadgesStack addArrangedSubview:[self badgeWithText:@"No FS" color:[UIColor systemPurpleColor]]];
+    if (unmuted)    [self.settingsBadgesStack addArrangedSubview:[self badgeWithText:@"Unmuted" color:[UIColor systemGreenColor]]];
+    if (hideCtrl)   [self.settingsBadgesStack addArrangedSubview:[self badgeWithText:@"No Ctrl" color:[UIColor systemOrangeColor]]];
+}
+
+- (UILabel *)badgeWithText:(NSString *)text color:(UIColor *)color {
+    UILabel *badge = [[UILabel alloc] init];
+    badge.text = [NSString stringWithFormat:@"  %@  ", text];
+    badge.font = [UIFont systemFontOfSize:9 weight:UIFontWeightBold];
+    badge.textColor = [UIColor whiteColor];
+    badge.backgroundColor = [color colorWithAlphaComponent:0.8];
+    badge.layer.cornerRadius = 8;
+    badge.clipsToBounds = YES;
+    badge.translatesAutoresizingMaskIntoConstraints = NO;
+    [badge.heightAnchor constraintEqualToConstant:16].active = YES;
+    return badge;
+}
+
+- (void)toggleSettingsPanel {
+    self.settingsPanelVisible = !self.settingsPanelVisible;
+    if (self.settingsPanelVisible) {
+        self.settingsPanel.hidden = NO;
+        [UIView animateWithDuration:0.25 animations:^{ self.settingsPanel.alpha = 1.0; }];
+    } else {
+        [UIView animateWithDuration:0.2 animations:^{
+            self.settingsPanel.alpha = 0;
+        } completion:^(BOOL finished) { self.settingsPanel.hidden = YES; }];
+    }
+}
+
+- (void)reloadAdsWithSettings {
+    for (ReelsAdItem *item in self.items) { [item.loader destroy]; }
+    [self.items removeAllObjects];
+    self.nextLoadIndex = 0;
+
+    BOOL hideCtrl = self.hideControlsSwitch.isOn;
+    for (NSInteger i = 0; i < kReelsAdCount; i++) {
+        ReelsAdItem *item = [[ReelsAdItem alloc] init];
+        if (i % 2 == 1) {
+            item.isImagePlaceholder = YES;
+            item.isLoaded = YES;
+        } else {
+            item.loader = [[CloudXCore shared] createNativeAdLoaderWithAdUnitIdentifier:[self adUnitId]];
+            item.loader.nativeAdDelegate = self;
+            item.loader.revenueDelegate = self;
+            item.loader.placement = [NSString stringWithFormat:@"reels_slot_%ld", (long)i];
+            item.loader.disableVideoFullScreen = self.fullScreenSwitch.isOn;
+            item.loader.startVideoUnmuted = self.unmutedSwitch.isOn;
+            item.loader.hideVideoMediaControls = hideCtrl;
+            item.hideControls = hideCtrl;
+        }
+        [self.items addObject:item];
+    }
+
+    [self.collectionView reloadData];
+    [self loadNextAd];
+    [self toggleSettingsPanel];
+    [self updateSettingsBadges];
+
+    NSString *reloadMsg = [NSString stringWithFormat:@"🔄 Reels reloading with: fullscreen=%@, unmuted=%@, hideControls=%@",
+          self.fullScreenSwitch.isOn ? @"OFF" : @"ON",
+          self.unmutedSwitch.isOn ? @"YES" : @"NO",
+          self.hideControlsSwitch.isOn ? @"YES" : @"NO"];
+    [[DemoAppLogger sharedInstance] logMessage:reloadMsg];
+}
+
+- (NSString *)adUnitId {
+    NSString *adUnitId = [[CLXDemoConfigManager sharedManager] currentConfig].nativeAdUnitId;
+    if ([UserDefaultsSettings sharedSettings].nativeMediumAdUnitId.length > 0) {
+        adUnitId = [UserDefaultsSettings sharedSettings].nativeMediumAdUnitId;
+    }
+    return adUnitId;
+}
+
+- (void)createItems {
+    self.items = [NSMutableArray arrayWithCapacity:kReelsAdCount];
+    self.nextLoadIndex = 0;
+
+    BOOL disableFS = self.fullScreenSwitch ? self.fullScreenSwitch.isOn : YES;
+    BOOL unmuted = self.unmutedSwitch ? self.unmutedSwitch.isOn : YES;
+    BOOL hideCtrl = self.hideControlsSwitch ? self.hideControlsSwitch.isOn : YES;
+
+    for (NSInteger i = 0; i < kReelsAdCount; i++) {
+        ReelsAdItem *item = [[ReelsAdItem alloc] init];
+        if (i % 2 == 1) {
+            item.isImagePlaceholder = YES;
+            item.isLoaded = YES;
+        } else {
+            item.loader = [[CloudXCore shared] createNativeAdLoaderWithAdUnitIdentifier:[self adUnitId]];
+            item.loader.nativeAdDelegate = self;
+            item.loader.revenueDelegate = self;
+            item.loader.placement = [NSString stringWithFormat:@"reels_slot_%ld", (long)i];
+            item.loader.disableVideoFullScreen = disableFS;
+            item.loader.startVideoUnmuted = unmuted;
+            item.loader.hideVideoMediaControls = hideCtrl;
+            item.hideControls = hideCtrl;
+        }
+        [self.items addObject:item];
+    }
+}
+
+#pragma mark - Sequential Loading
+
+- (void)loadNextAd {
+    while (self.nextLoadIndex < kReelsAdCount && self.items[self.nextLoadIndex].isImagePlaceholder) {
+        self.nextLoadIndex++;
+    }
+    if (self.nextLoadIndex >= kReelsAdCount) return;
+
+    ReelsAdItem *item = self.items[self.nextLoadIndex];
+    item.isLoading = YES;
+    [item.loader loadAd];
+}
+
+#pragma mark - CLXNativeAdDelegate
+
+- (void)didLoadNativeAd:(nullable CLXNativeAdView *)nativeAdView forAd:(CLXAd *)ad {
+    NSInteger idx = self.nextLoadIndex;
+    if (idx >= kReelsAdCount) return;
+
+    ReelsAdItem *item = self.items[idx];
+    item.isLoading = NO;
+    item.isLoaded = YES;
+    item.ad = ad;
+    item.nativeAd = ad.nativeAd;
+
+    NSString *creativeType = ad.nativeAd.isVideoContent ? @"video" : @"static";
+    NSString *msg = [NSString stringWithFormat:@"✅ Reels didLoadNativeAd (slot %ld, %@, duration=%.1fs)", (long)idx, creativeType, ad.nativeAd.videoDuration];
+    [[DemoAppLogger sharedInstance] logAdEvent:msg ad:ad];
+
+    [self.collectionView reloadItemsAtIndexPaths:@[[NSIndexPath indexPathForItem:idx inSection:0]]];
+
+    self.nextLoadIndex++;
+    [self loadNextAd];
+}
+
+- (void)didFailToLoadNativeAdForAdUnitIdentifier:(NSString *)adUnitId error:(CLXError *)error {
+    NSInteger idx = self.nextLoadIndex;
+    if (idx >= kReelsAdCount) return;
+
+    ReelsAdItem *item = self.items[idx];
+    item.isLoading = NO;
+    item.isFailed = YES;
+
+    NSString *msg = [NSString stringWithFormat:@"❌ Reels didFailToLoadNativeAd (slot %ld): %@", (long)idx, error.localizedDescription];
+    [[DemoAppLogger sharedInstance] logMessage:msg];
+
+    [self.collectionView reloadItemsAtIndexPaths:@[[NSIndexPath indexPathForItem:idx inSection:0]]];
+
+    self.nextLoadIndex++;
+    [self loadNextAd];
+}
+
+- (void)didClickNativeAd:(CLXAd *)ad {
+    [[DemoAppLogger sharedInstance] logAdEvent:@"👆 Reels didClickNativeAd" ad:ad];
+}
+
+- (void)didExpireNativeAd:(CLXAd *)ad {
+    [[DemoAppLogger sharedInstance] logAdEvent:@"⏰ Reels didExpireNativeAd" ad:ad];
+}
+
+- (void)didCloseNativeAd:(CLXAd *)ad {
+    [[DemoAppLogger sharedInstance] logAdEvent:@"🚪 Reels didCloseNativeAd — user reported/hid ad via AdChoices" ad:ad];
+
+    NSInteger closedIdx = NSNotFound;
+    for (NSInteger i = 0; i < self.items.count; i++) {
+        if (self.items[i].ad == ad) { closedIdx = i; break; }
+    }
+
+    [self showDismissToast];
+
+    if (closedIdx != NSNotFound && closedIdx + 1 < kReelsAdCount) {
+        __weak typeof(self) weakSelf = self;
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.8 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+            __strong typeof(weakSelf) strongSelf = weakSelf;
+            if (!strongSelf) return;
+            NSIndexPath *next = [NSIndexPath indexPathForItem:closedIdx + 1 inSection:0];
+            [strongSelf.collectionView scrollToItemAtIndexPath:next atScrollPosition:UICollectionViewScrollPositionCenteredVertically animated:YES];
+        });
+    }
+}
+
+- (void)showDismissToast {
+    UILabel *toast = [[UILabel alloc] init];
+    toast.text = @"  Ad reported by user — moving to next  ";
+    toast.font = [UIFont systemFontOfSize:13 weight:UIFontWeightMedium];
+    toast.textColor = [UIColor whiteColor];
+    toast.backgroundColor = [[UIColor blackColor] colorWithAlphaComponent:0.75];
+    toast.textAlignment = NSTextAlignmentCenter;
+    toast.layer.cornerRadius = 16;
+    toast.clipsToBounds = YES;
+    toast.translatesAutoresizingMaskIntoConstraints = NO;
+    toast.alpha = 0;
+    [self.view addSubview:toast];
+
+    [NSLayoutConstraint activateConstraints:@[
+        [toast.centerXAnchor constraintEqualToAnchor:self.view.centerXAnchor],
+        [toast.bottomAnchor constraintEqualToAnchor:self.view.safeAreaLayoutGuide.bottomAnchor constant:-20],
+        [toast.heightAnchor constraintEqualToConstant:32],
+    ]];
+
+    [UIView animateWithDuration:0.3 animations:^{ toast.alpha = 1.0; }];
+
+    __weak UILabel *weakToast = toast;
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(2.0 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        [UIView animateWithDuration:0.3 animations:^{
+            weakToast.alpha = 0;
+        } completion:^(BOOL finished) {
+            [weakToast removeFromSuperview];
+        }];
+    });
+}
+
+#pragma mark - CLXAdRevenueDelegate
+
+- (void)didPayRevenueForAd:(CLXAd *)ad {
+    [[DemoAppLogger sharedInstance] logAdEvent:@"💰 Reels didPayRevenueForAd" ad:ad];
+}
+
+#pragma mark - UICollectionViewDataSource
+
+- (NSInteger)collectionView:(UICollectionView *)collectionView numberOfItemsInSection:(NSInteger)section {
+    return kReelsAdCount;
+}
+
+- (__kindof UICollectionViewCell *)collectionView:(UICollectionView *)collectionView cellForItemAtIndexPath:(NSIndexPath *)indexPath {
+    ReelsCell *cell = [collectionView dequeueReusableCellWithReuseIdentifier:kReelsCellIdentifier forIndexPath:indexPath];
+    ReelsAdItem *item = self.items[indexPath.item];
+    [cell configureWithItem:item atIndex:indexPath.item];
+
+    if (item.isLoaded && !item.isImagePlaceholder && item.ad) {
+        [item.loader renderNativeAdView:cell.nativeAdView withAd:item.ad];
+    }
+
+    return cell;
+}
+
+#pragma mark - UICollectionViewDelegateFlowLayout
+
+- (CGSize)collectionView:(UICollectionView *)collectionView layout:(UICollectionViewLayout *)collectionViewLayout sizeForItemAtIndexPath:(NSIndexPath *)indexPath {
+    return collectionView.bounds.size;
+}
+
+@end

--- a/demo-app-swift/CloudXSwiftRemotePods/Configuration/CLXDemoConfigManager.swift
+++ b/demo-app-swift/CloudXSwiftRemotePods/Configuration/CLXDemoConfigManager.swift
@@ -47,8 +47,8 @@ class CLXDemoConfigManager {
             bannerAdUnitId: "Ce5-ltAX5zFz5QJ3TzEjY",
             mrecAdUnitId: "xMLHNFIkwieu2SLyeD0sQ",
             interstitialAdUnitId: "rkw0ncj6mSphKtmnl8Cw_",
-            nativeAdUnitId: "-",
-            nativeBannerAdUnitId: "-",
+            nativeAdUnitId: "Q33RbPmBH-wix45Mu6--Z",
+            nativeBannerAdUnitId: "-2_Lw2b4QTlu7x6tKZ6Ww",
             rewardedAdUnitId: "WJje0XGqL5n56Sa8dlt8L",
             rewardedInterstitialAdUnitId: "-"
         )

--- a/demo-app-swift/CloudXSwiftRemotePods/DeepLinkRouter.swift
+++ b/demo-app-swift/CloudXSwiftRemotePods/DeepLinkRouter.swift
@@ -12,6 +12,7 @@ enum DeepLinkRouter {
         "mrec":                  "MRECViewController",
         "interstitial":          "InterstitialViewController",
         "rewarded":              "RewardedViewController",
+        "native":                "NativeMenuViewController",
     ]
 
     static func setup() {
@@ -42,7 +43,15 @@ private final class Adapter: NSObject, CLXTestHarnessApp {
         guard let tabVC = resolveTabViewController(),
               let tabIndex = tabIndex(for: format, in: tabVC) else { return nil }
         tabVC.selectTab(at: tabIndex)
-        return vcAtTabIndex(tabIndex, in: tabVC)
+        let contentVC = vcAtTabIndex(tabIndex, in: tabVC)
+
+        if format == "native", let navVC = contentVC?.navigationController {
+            let nativeVC = NativeViewController()
+            navVC.pushViewController(nativeVC, animated: false)
+            return nativeVC
+        }
+
+        return contentVC
     }
 
     func navigateToInit() -> UIViewController? {
@@ -54,7 +63,7 @@ private final class Adapter: NSObject, CLXTestHarnessApp {
     // MARK: - Format Configuration
 
     func supportedFormats() -> [String] {
-        ["banner", "mrec", "interstitial", "rewarded"]
+        ["banner", "mrec", "interstitial", "rewarded", "native"]
     }
 
     func isFullscreenFormat(_ format: String) -> Bool {
@@ -67,6 +76,7 @@ private final class Adapter: NSObject, CLXTestHarnessApp {
         case "mrec":                  return NSSelectorFromString("loadMRECAd")
         case "interstitial":          return NSSelectorFromString("loadInterstitialAd")
         case "rewarded":              return NSSelectorFromString("loadRewardedAd")
+        case "native":                return NSSelectorFromString("loadNativeAd")
         default:                      return nil
         }
     }

--- a/demo-app-swift/CloudXSwiftRemotePods/DeepLinkRouter.swift
+++ b/demo-app-swift/CloudXSwiftRemotePods/DeepLinkRouter.swift
@@ -45,7 +45,11 @@ private final class Adapter: NSObject, CLXTestHarnessApp {
         tabVC.selectTab(at: tabIndex)
         let contentVC = vcAtTabIndex(tabIndex, in: tabVC)
 
-        if format == "native", let navVC = contentVC?.navigationController {
+        if format == "native" {
+            guard let navVC = contentVC?.navigationController else {
+                logMessage("Native tab has no UINavigationController — cannot push NativeViewController")
+                return nil
+            }
             let nativeVC = NativeViewController()
             navVC.pushViewController(nativeVC, animated: false)
             return nativeVC

--- a/demo-app-swift/CloudXSwiftRemotePods/Views/Ad/AdDemoTabViewController.swift
+++ b/demo-app-swift/CloudXSwiftRemotePods/Views/Ad/AdDemoTabViewController.swift
@@ -27,12 +27,15 @@ class AdDemoTabViewController: UITabBarController {
         
         let mrecVC = MRECViewController()
         mrecVC.tabBarItem = UITabBarItem(title: "MREC", image: UIImage(systemName: "rectangle.3.group"), tag: 4)
-        
+
+        let nativeVC = NativeMenuViewController()
+        nativeVC.tabBarItem = UITabBarItem(title: "Native", image: UIImage(systemName: "doc.richtext"), tag: 5)
+
         let keyValueVC = KeyValueDemoViewController()
-        keyValueVC.tabBarItem = UITabBarItem(title: "Key-Values", image: UIImage(systemName: "key.fill"), tag: 5)
+        keyValueVC.tabBarItem = UITabBarItem(title: "Key-Values", image: UIImage(systemName: "key.fill"), tag: 6)
         
         let settingsVC = SettingsViewController()
-        settingsVC.tabBarItem = UITabBarItem(title: "Settings", image: UIImage(systemName: "gearshape"), tag: 6)
+        settingsVC.tabBarItem = UITabBarItem(title: "Settings", image: UIImage(systemName: "gearshape"), tag: 7)
         
         // Set view controllers - Additional VCs appear in "More" section
         self.viewControllers = [
@@ -41,6 +44,7 @@ class AdDemoTabViewController: UITabBarController {
             UINavigationController(rootViewController: interstitialVC),
             UINavigationController(rootViewController: rewardedVC),
             UINavigationController(rootViewController: mrecVC),
+            UINavigationController(rootViewController: nativeVC),
             UINavigationController(rootViewController: keyValueVC),
             UINavigationController(rootViewController: settingsVC)
         ]

--- a/demo-app-swift/CloudXSwiftRemotePods/Views/Ad/NativeFeedViewController.swift
+++ b/demo-app-swift/CloudXSwiftRemotePods/Views/Ad/NativeFeedViewController.swift
@@ -1,0 +1,292 @@
+import UIKit
+import CloudXCore
+
+private let kAdCount = 10
+
+private enum NativeAdCreativeType {
+    case unknown, image, videoLandscape, videoPortrait
+
+    var badgeText: String {
+        switch self {
+        case .unknown: return "UNKNOWN"
+        case .image: return "IMAGE"
+        case .videoLandscape: return "VIDEO 16:9"
+        case .videoPortrait: return "REELS 9:16"
+        }
+    }
+
+    var badgeColor: UIColor {
+        switch self {
+        case .unknown: return .systemGray
+        case .image: return .systemBlue
+        case .videoLandscape: return .systemOrange
+        case .videoPortrait: return .systemPurple
+        }
+    }
+}
+
+private class NativeAdFeedItem {
+    let loader: CLXNativeAdLoader
+    var adView: CLXNativeAdView?
+    var ad: CLXAd?
+    var creativeType: NativeAdCreativeType = .unknown
+    var isLoading = false
+    var isLoaded = false
+    var isFailed = false
+
+    init(loader: CLXNativeAdLoader) {
+        self.loader = loader
+    }
+}
+
+class NativeFeedViewController: UIViewController, UITableViewDataSource, UITableViewDelegate,
+                                 CLXNativeAdDelegate, CLXAdRevenueDelegate {
+
+    private let tableView = UITableView(frame: .zero, style: .plain)
+    private var feedItems: [NativeAdFeedItem] = []
+    private var nextLoadIndex = 0
+    private let settings = UserDefaultsSettings.shared
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        title = "Native Feed"
+        view.backgroundColor = .systemBackground
+        setupTableView()
+        setupAppLogsButton()
+        createFeedItems()
+        loadNextAd()
+    }
+
+    deinit {
+        feedItems.forEach { $0.loader.destroy() }
+    }
+
+    // MARK: - Setup
+
+    private func setupTableView() {
+        tableView.translatesAutoresizingMaskIntoConstraints = false
+        tableView.dataSource = self
+        tableView.delegate = self
+        tableView.separatorStyle = .none
+        tableView.allowsSelection = false
+        tableView.register(UITableViewCell.self, forCellReuseIdentifier: "NativeAdCell")
+        view.addSubview(tableView)
+
+        NSLayoutConstraint.activate([
+            tableView.topAnchor.constraint(equalTo: view.topAnchor),
+            tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+        ])
+    }
+
+    private func setupAppLogsButton() {
+        let logsButton = UIButton(type: .system)
+        logsButton.setTitle("App Logs", for: .normal)
+        logsButton.titleLabel?.font = .systemFont(ofSize: 14, weight: .medium)
+        logsButton.backgroundColor = .systemOrange
+        logsButton.setTitleColor(.white, for: .normal)
+        logsButton.layer.cornerRadius = 6
+        logsButton.translatesAutoresizingMaskIntoConstraints = false
+        logsButton.addTarget(self, action: #selector(showLogsModal), for: .touchUpInside)
+        view.addSubview(logsButton)
+
+        NSLayoutConstraint.activate([
+            logsButton.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 8),
+            logsButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -12),
+            logsButton.widthAnchor.constraint(equalToConstant: 90),
+            logsButton.heightAnchor.constraint(equalToConstant: 30),
+        ])
+    }
+
+    @objc private func showLogsModal() {
+        let logsModal = LogsModalViewController(title: "Logs")
+        present(logsModal, animated: true)
+    }
+
+    private var adUnitId: String {
+        let id = CLXDemoConfigManager.sharedManager.currentConfig.nativeAdUnitId
+        return settings.nativeMediumAdUnitId.isEmpty ? id : settings.nativeMediumAdUnitId
+    }
+
+    private func createFeedItems() {
+        for i in 0..<kAdCount {
+            let loader = CloudXCore.shared.createNativeAdLoader(adUnitIdentifier: adUnitId)
+            loader.nativeAdDelegate = self
+            loader.revenueDelegate = self
+            loader.placement = "feed_slot_\(i)"
+            feedItems.append(NativeAdFeedItem(loader: loader))
+        }
+    }
+
+    // MARK: - Sequential Loading
+
+    private func loadNextAd() {
+        guard nextLoadIndex < kAdCount else { return }
+        let item = feedItems[nextLoadIndex]
+        item.isLoading = true
+        item.loader.loadAd()
+    }
+
+    // MARK: - Creative Type Detection
+
+    private func detectCreativeType(from ad: CLXAd) -> NativeAdCreativeType {
+        guard let nativeAd = ad.nativeAd else { return .unknown }
+
+        if nativeAd.isVideoContent {
+            let ar = nativeAd.mediaContentAspectRatio
+            return ar < 1.0 ? .videoPortrait : .videoLandscape
+        }
+
+        return nativeAd.mediaContentAspectRatio > 0 ? .image : .unknown
+    }
+
+    // MARK: - CLXNativeAdDelegate
+
+    func didLoadNativeAd(_ nativeAdView: CLXNativeAdView?, for ad: CLXAd) {
+        let idx = nextLoadIndex
+        guard idx < kAdCount else { return }
+
+        let item = feedItems[idx]
+        item.isLoading = false
+        item.isLoaded = true
+        item.ad = ad
+
+        if let view = nativeAdView {
+            item.adView = view
+        } else if let nativeAd = ad.nativeAd {
+            let templateView = CLXNativeAdView(from: nativeAd)
+            item.loader.renderNativeAdView(templateView, with: ad)
+            item.adView = templateView
+        }
+
+        item.creativeType = detectCreativeType(from: ad)
+        DemoAppLogger.sharedInstance.logMessage("✅ Feed slot \(idx) loaded: \(item.creativeType.badgeText)")
+
+        tableView.reloadRows(at: [IndexPath(row: idx, section: 0)], with: .fade)
+
+        nextLoadIndex += 1
+        loadNextAd()
+    }
+
+    func didFailToLoadNativeAd(forAdUnitIdentifier adUnitId: String, error: CLXError) {
+        let idx = nextLoadIndex
+        guard idx < kAdCount else { return }
+
+        let item = feedItems[idx]
+        item.isLoading = false
+        item.isFailed = true
+
+        DemoAppLogger.sharedInstance.logMessage("❌ Feed slot \(idx) failed: \(error.localizedDescription)")
+
+        tableView.reloadRows(at: [IndexPath(row: idx, section: 0)], with: .fade)
+
+        nextLoadIndex += 1
+        loadNextAd()
+    }
+
+    func didClickNativeAd(_ ad: CLXAd) {
+        DemoAppLogger.sharedInstance.logAdEvent("👆 Feed didClickNativeAd", ad: ad)
+    }
+
+    func didExpireNativeAd(_ ad: CLXAd) {
+        DemoAppLogger.sharedInstance.logAdEvent("⏰ Feed didExpireNativeAd", ad: ad)
+    }
+
+    // MARK: - CLXAdRevenueDelegate
+
+    func didPayRevenue(for ad: CLXAd) {
+        DemoAppLogger.sharedInstance.logAdEvent("💰 Feed didPayRevenueForAd", ad: ad)
+    }
+
+    // MARK: - UITableViewDataSource
+
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int { kAdCount }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: "NativeAdCell", for: indexPath)
+        cell.contentView.subviews.forEach { $0.removeFromSuperview() }
+
+        let item = feedItems[indexPath.row]
+
+        if item.isLoaded, let adView = item.adView {
+            adView.translatesAutoresizingMaskIntoConstraints = false
+            cell.contentView.addSubview(adView)
+            NSLayoutConstraint.activate([
+                adView.topAnchor.constraint(equalTo: cell.contentView.topAnchor, constant: 8),
+                adView.leadingAnchor.constraint(equalTo: cell.contentView.leadingAnchor, constant: 12),
+                adView.trailingAnchor.constraint(equalTo: cell.contentView.trailingAnchor, constant: -12),
+                adView.bottomAnchor.constraint(equalTo: cell.contentView.bottomAnchor, constant: -8),
+            ])
+
+            let badge = UILabel()
+            badge.text = " \(item.creativeType.badgeText) "
+            badge.font = .boldSystemFont(ofSize: 11)
+            badge.textColor = .white
+            badge.backgroundColor = item.creativeType.badgeColor
+            badge.layer.cornerRadius = 4
+            badge.clipsToBounds = true
+            badge.translatesAutoresizingMaskIntoConstraints = false
+            cell.contentView.addSubview(badge)
+
+            let slotLabel = UILabel()
+            slotLabel.text = "Slot \(indexPath.row)"
+            slotLabel.font = .monospacedSystemFont(ofSize: 10, weight: .medium)
+            slotLabel.textColor = .tertiaryLabel
+            slotLabel.translatesAutoresizingMaskIntoConstraints = false
+            cell.contentView.addSubview(slotLabel)
+
+            NSLayoutConstraint.activate([
+                badge.topAnchor.constraint(equalTo: cell.contentView.topAnchor, constant: 14),
+                badge.trailingAnchor.constraint(equalTo: cell.contentView.trailingAnchor, constant: -18),
+                slotLabel.topAnchor.constraint(equalTo: cell.contentView.topAnchor, constant: 14),
+                slotLabel.leadingAnchor.constraint(equalTo: cell.contentView.leadingAnchor, constant: 18),
+            ])
+        } else if item.isFailed {
+            let errorLabel = UILabel()
+            errorLabel.text = "Slot \(indexPath.row) — Load Failed"
+            errorLabel.textColor = .systemRed
+            errorLabel.font = .preferredFont(forTextStyle: .subheadline)
+            errorLabel.textAlignment = .center
+            errorLabel.translatesAutoresizingMaskIntoConstraints = false
+            cell.contentView.addSubview(errorLabel)
+            NSLayoutConstraint.activate([
+                errorLabel.centerXAnchor.constraint(equalTo: cell.contentView.centerXAnchor),
+                errorLabel.centerYAnchor.constraint(equalTo: cell.contentView.centerYAnchor),
+            ])
+        } else {
+            let spinner = UIActivityIndicatorView(style: .medium)
+            spinner.translatesAutoresizingMaskIntoConstraints = false
+            spinner.startAnimating()
+            cell.contentView.addSubview(spinner)
+
+            let loadingLabel = UILabel()
+            loadingLabel.text = "Slot \(indexPath.row) — Loading..."
+            loadingLabel.textColor = .secondaryLabel
+            loadingLabel.font = .preferredFont(forTextStyle: .subheadline)
+            loadingLabel.translatesAutoresizingMaskIntoConstraints = false
+            cell.contentView.addSubview(loadingLabel)
+
+            NSLayoutConstraint.activate([
+                spinner.centerYAnchor.constraint(equalTo: cell.contentView.centerYAnchor),
+                spinner.trailingAnchor.constraint(equalTo: loadingLabel.leadingAnchor, constant: -8),
+                loadingLabel.centerXAnchor.constraint(equalTo: cell.contentView.centerXAnchor, constant: 12),
+                loadingLabel.centerYAnchor.constraint(equalTo: cell.contentView.centerYAnchor),
+            ])
+        }
+
+        cell.backgroundColor = .clear
+        cell.contentView.backgroundColor = .clear
+        return cell
+    }
+
+    // MARK: - UITableViewDelegate
+
+    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        let item = feedItems[indexPath.row]
+        if item.isLoaded {
+            return item.creativeType == .videoPortrait ? 600 : 400
+        }
+        return 80
+    }
+}

--- a/demo-app-swift/CloudXSwiftRemotePods/Views/Ad/NativeMenuViewController.swift
+++ b/demo-app-swift/CloudXSwiftRemotePods/Views/Ad/NativeMenuViewController.swift
@@ -1,0 +1,68 @@
+import UIKit
+import FBAudienceNetwork
+
+class NativeMenuViewController: UITableViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        title = "Native"
+        tableView.register(UITableViewCell.self, forCellReuseIdentifier: "MenuCell")
+    }
+
+    // MARK: - UITableViewDataSource
+
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int { 3 }
+
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: "MenuCell", for: indexPath)
+        cell.accessoryType = .disclosureIndicator
+
+        if #available(iOS 14.0, *) {
+            var config = UIListContentConfiguration.cell()
+            switch indexPath.row {
+            case 0:
+                config.text = "Single Ad — Image"
+                config.secondaryText = "Template / Manual / Late-binding flows"
+                config.image = UIImage(systemName: "photo")
+            case 1:
+                config.text = "Feed — Video 16:9"
+                config.secondaryText = "Scrollable feed with landscape video ads"
+                config.image = UIImage(systemName: "rectangle.stack")
+            case 2:
+                config.text = "Reels — Video 9:16"
+                config.secondaryText = "Full-screen vertical paging — swipe to advance"
+                config.image = UIImage(systemName: "play.rectangle.fill")
+            default: break
+            }
+            cell.contentConfiguration = config
+        } else {
+            switch indexPath.row {
+            case 0: cell.textLabel?.text = "Single Ad — Image"
+            case 1: cell.textLabel?.text = "Feed — Video 16:9"
+            case 2: cell.textLabel?.text = "Reels — Video 9:16"
+            default: break
+            }
+        }
+
+        return cell
+    }
+
+    // MARK: - UITableViewDelegate
+
+    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
+
+        switch indexPath.row {
+        case 0:
+            FBAdSettings.testAdType = .img_16_9_App_Install
+            navigationController?.pushViewController(NativeViewController(), animated: true)
+        case 1:
+            FBAdSettings.testAdType = .vid_HD_16_9_46s_App_Install
+            navigationController?.pushViewController(NativeFeedViewController(), animated: true)
+        case 2:
+            FBAdSettings.testAdType = .vid_HD_9_16_39s_App_Install
+            navigationController?.pushViewController(ReelsFeedViewController(), animated: true)
+        default: break
+        }
+    }
+}

--- a/demo-app-swift/CloudXSwiftRemotePods/Views/Ad/NativeViewController.swift
+++ b/demo-app-swift/CloudXSwiftRemotePods/Views/Ad/NativeViewController.swift
@@ -1,0 +1,621 @@
+import UIKit
+import CloudXCore
+
+private enum NativeFlow: Int {
+    case template = 0
+    case manual = 1
+    case lateBinding = 2
+}
+
+class NativeViewController: BaseAdViewController {
+    private var nativeAdLoader: CLXNativeAdLoader?
+    private var nativeAdView: CLXNativeAdView?
+    private var loadedAd: CLXAd?
+    private let adContainerView = UIView()
+    private let settings = UserDefaultsSettings.shared
+    private var activeFlow: NativeFlow = .template
+    private let flowPicker = UISegmentedControl(items: ["A: Template", "B: Manual", "C: Late-Bind"])
+    private let flowDescription = UILabel()
+    private var loadButton: UIButton!
+    private var bindButton: UIButton!
+    private let flowBanner = UILabel()
+    private var preloadedAd: CLXAd?
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        title = "Native"
+        setupUI()
+        updateStatusUI(state: .noAd)
+        flowPickerChanged()
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        resetAdState()
+    }
+
+    deinit {
+        nativeAdLoader?.destroy()
+    }
+
+    // MARK: - UI
+
+    private func setupUI() {
+        flowDescription.font = .systemFont(ofSize: 13, weight: .medium)
+        flowDescription.textColor = .label
+        flowDescription.textAlignment = .left
+        flowDescription.numberOfLines = 0
+        flowDescription.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(flowDescription)
+
+        NSLayoutConstraint.activate([
+            flowDescription.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 8),
+            flowDescription.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 16),
+            flowDescription.trailingAnchor.constraint(lessThanOrEqualTo: view.trailingAnchor, constant: -140),
+            flowDescription.bottomAnchor.constraint(lessThanOrEqualTo: view.safeAreaLayoutGuide.topAnchor, constant: 90),
+        ])
+
+        let scrollView = UIScrollView()
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        scrollView.alwaysBounceVertical = true
+        view.addSubview(scrollView)
+
+        let contentStack = UIStackView()
+        contentStack.axis = .vertical
+        contentStack.spacing = 6
+        contentStack.alignment = .fill
+        contentStack.translatesAutoresizingMaskIntoConstraints = false
+        scrollView.addSubview(contentStack)
+
+        flowPicker.selectedSegmentIndex = 0
+        flowPicker.addTarget(self, action: #selector(flowPickerChanged), for: .valueChanged)
+        contentStack.addArrangedSubview(flowPicker)
+
+        loadButton = UIButton(type: .system)
+        loadButton.setTitleColor(.white, for: .normal)
+        loadButton.titleLabel?.font = .boldSystemFont(ofSize: 14)
+        loadButton.layer.cornerRadius = 8
+        loadButton.translatesAutoresizingMaskIntoConstraints = false
+        loadButton.addTarget(self, action: #selector(loadAction), for: .touchUpInside)
+
+        let destroyButton = UIButton(type: .system)
+        destroyButton.setTitle("Destroy", for: .normal)
+        destroyButton.setTitleColor(.systemRed, for: .normal)
+        destroyButton.titleLabel?.font = .systemFont(ofSize: 13, weight: .medium)
+        destroyButton.addTarget(self, action: #selector(destroyAd), for: .touchUpInside)
+
+        let leftSpacer = UIView()
+        let rightSpacer = UIView()
+        let buttonRow = UIStackView(arrangedSubviews: [leftSpacer, loadButton, destroyButton, rightSpacer])
+        buttonRow.axis = .horizontal
+        buttonRow.spacing = 8
+        buttonRow.alignment = .center
+        contentStack.addArrangedSubview(buttonRow)
+
+        NSLayoutConstraint.activate([
+            loadButton.widthAnchor.constraint(equalToConstant: 200),
+            loadButton.heightAnchor.constraint(equalToConstant: 36),
+            leftSpacer.widthAnchor.constraint(equalTo: rightSpacer.widthAnchor),
+        ])
+
+        bindButton = UIButton(type: .system)
+        bindButton.setTitle("Step 2: Bind & Display", for: .normal)
+        bindButton.setTitleColor(.white, for: .normal)
+        bindButton.titleLabel?.font = .boldSystemFont(ofSize: 14)
+        bindButton.backgroundColor = .systemTeal
+        bindButton.layer.cornerRadius = 8
+        bindButton.isHidden = true
+        bindButton.alpha = 0
+        bindButton.addTarget(self, action: #selector(bindPreloadedAd), for: .touchUpInside)
+        contentStack.addArrangedSubview(bindButton)
+        bindButton.heightAnchor.constraint(equalToConstant: 36).isActive = true
+
+        flowBanner.font = .monospacedSystemFont(ofSize: 11, weight: .bold)
+        flowBanner.textAlignment = .center
+        flowBanner.numberOfLines = 0
+        flowBanner.textColor = .secondaryLabel
+        contentStack.addArrangedSubview(flowBanner)
+
+        adContainerView.translatesAutoresizingMaskIntoConstraints = false
+        adContainerView.clipsToBounds = true
+        contentStack.addArrangedSubview(adContainerView)
+        adContainerView.heightAnchor.constraint(greaterThanOrEqualToConstant: 400).isActive = true
+
+        let pad: CGFloat = 16
+        NSLayoutConstraint.activate([
+            scrollView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 100),
+            scrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: statusStack.topAnchor, constant: -4),
+
+            contentStack.topAnchor.constraint(equalTo: scrollView.topAnchor),
+            contentStack.leadingAnchor.constraint(equalTo: scrollView.leadingAnchor, constant: pad),
+            contentStack.trailingAnchor.constraint(equalTo: scrollView.trailingAnchor, constant: -pad),
+            contentStack.bottomAnchor.constraint(equalTo: scrollView.bottomAnchor, constant: -pad),
+            contentStack.widthAnchor.constraint(equalTo: scrollView.widthAnchor, constant: -pad * 2),
+        ])
+    }
+
+    @objc private func flowPickerChanged() {
+        activeFlow = NativeFlow(rawValue: flowPicker.selectedSegmentIndex) ?? .template
+
+        switch activeFlow {
+        case .template:
+            flowDescription.text = "Template — SDK auto-generates the ad view. Zero custom UI code. Just load and the SDK handles layout."
+            loadButton.setTitle("Load Ad", for: .normal)
+            loadButton.backgroundColor = .systemGreen
+        case .manual:
+            flowDescription.text = "Manual — Publisher builds a fully custom layout. Every element is positioned and styled by your code."
+            loadButton.setTitle("Load Ad", for: .normal)
+            loadButton.backgroundColor = .systemBlue
+        case .lateBinding:
+            flowDescription.text = "Late-Bind — Pre-load ad data headlessly, then bind to any custom view on demand. A two-step process."
+            loadButton.setTitle("Step 1: Pre-load", for: .normal)
+            loadButton.backgroundColor = .systemOrange
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func updateFlowBanner(text: String, color: UIColor) {
+        flowBanner.text = text
+        flowBanner.textColor = color
+    }
+
+    private func showBindButton(_ show: Bool) {
+        if show, bindButton.isHidden {
+            bindButton.isHidden = false
+            UIView.animate(withDuration: 0.3) { self.bindButton.alpha = 1.0 }
+        } else if !show, !bindButton.isHidden {
+            UIView.animate(withDuration: 0.2, animations: {
+                self.bindButton.alpha = 0
+            }, completion: { _ in self.bindButton.isHidden = true })
+        }
+    }
+
+    // MARK: - Ad Unit
+
+    private var adUnitId: String {
+        let id = CLXDemoConfigManager.sharedManager.currentConfig.nativeAdUnitId
+        return settings.nativeMediumAdUnitId.isEmpty ? id : settings.nativeMediumAdUnitId
+    }
+
+    private func ensureLoader() -> CLXNativeAdLoader {
+        if let loader = nativeAdLoader { return loader }
+        let loader = cloudX.createNativeAdLoader(adUnitIdentifier: adUnitId)
+        loader.nativeAdDelegate = self
+        loader.revenueDelegate = self
+        loader.placement = "demo_native"
+        nativeAdLoader = loader
+        return loader
+    }
+
+    // MARK: - Load Action
+
+    @objc private func loadAction() {
+        switch activeFlow {
+        case .template:    loadTemplate()
+        case .manual:      loadManual()
+        case .lateBinding: loadLateBinding()
+        }
+    }
+
+    // MARK: - Flow A: Template
+
+    private func loadTemplate() {
+        guard !isLoading else {
+            showAlert(title: "Info", message: "Native ad is already loading.")
+            return
+        }
+        resetAdState()
+        activeFlow = .template
+        isLoading = true
+        updateStatusUI(state: .loading)
+        updateFlowBanner(text: "Loading template...", color: .secondaryLabel)
+        ensureLoader().loadAd()
+    }
+
+    // MARK: - Flow B: Manual
+
+    private func loadManual() {
+        guard !isLoading else {
+            showAlert(title: "Info", message: "Native ad is already loading.")
+            return
+        }
+        resetAdState()
+        activeFlow = .manual
+
+        let adView = buildManualAdView()
+        let binder = CLXNativeAdViewBinder(builderBlock: { builder in
+            builder.titleLabelTag = CLXNativeAdViewTagTitleLabel
+            builder.bodyLabelTag = CLXNativeAdViewTagBodyLabel
+            builder.callToActionButtonTag = CLXNativeAdViewTagCallToActionButton
+            builder.iconImageViewTag = CLXNativeAdViewTagIconImageView
+            builder.mediaContentViewTag = CLXNativeAdViewTagMediaViewContainer
+            builder.advertiserLabelTag = CLXNativeAdViewTagAdvertiserLabel
+            builder.optionsContentViewTag = CLXNativeAdViewTagOptionsContentView
+        })
+        adView.bindViews(with: binder)
+
+        isLoading = true
+        updateStatusUI(state: .loading)
+        updateFlowBanner(text: "Loading into custom publisher layout...", color: .secondaryLabel)
+        ensureLoader().loadAd(into: adView)
+    }
+
+    // MARK: - Flow C: Late-Binding (2-step)
+
+    private func loadLateBinding() {
+        guard !isLoading else {
+            showAlert(title: "Info", message: "Native ad is already loading.")
+            return
+        }
+        resetAdState()
+        activeFlow = .lateBinding
+        isLoading = true
+        updateStatusUI(state: .loading)
+        updateFlowBanner(text: "Step 1: Loading headlessly...", color: .secondaryLabel)
+        ensureLoader().loadAd()
+    }
+
+    @objc private func bindPreloadedAd() {
+        guard let ad = preloadedAd else { return }
+
+        let spotlightView = buildSpotlightAdView()
+        let binder = CLXNativeAdViewBinder(builderBlock: { builder in
+            builder.titleLabelTag = CLXNativeAdViewTagTitleLabel
+            builder.bodyLabelTag = CLXNativeAdViewTagBodyLabel
+            builder.callToActionButtonTag = CLXNativeAdViewTagCallToActionButton
+            builder.iconImageViewTag = CLXNativeAdViewTagIconImageView
+            builder.mediaContentViewTag = CLXNativeAdViewTagMediaViewContainer
+            builder.advertiserLabelTag = CLXNativeAdViewTagAdvertiserLabel
+            builder.optionsContentViewTag = CLXNativeAdViewTagOptionsContentView
+        })
+        spotlightView.bindViews(with: binder)
+        ensureLoader().renderNativeAdView(spotlightView, with: ad)
+        displayAdView(spotlightView)
+
+        preloadedAd = nil
+        showBindButton(false)
+        updateFlowBanner(text: "COMPLETE — Bound to custom view on demand", color: .systemGreen)
+        DemoAppLogger.sharedInstance.logMessage("Flow C Step 2: Bound pre-loaded ad to spotlight view")
+    }
+
+    // MARK: - Destroy
+
+    @objc private func destroyAd() {
+        resetAdState()
+        DemoAppLogger.sharedInstance.logMessage("Native ad destroyed")
+    }
+
+    private func resetAdState() {
+        if let ad = loadedAd {
+            nativeAdLoader?.destroy(ad)
+            loadedAd = nil
+        }
+        nativeAdView?.removeFromSuperview()
+        nativeAdView = nil
+        nativeAdLoader?.destroy()
+        nativeAdLoader = nil
+        preloadedAd = nil
+        isLoading = false
+        showBindButton(false)
+        updateStatusUI(state: .noAd)
+        flowBanner.text = nil
+    }
+
+    // MARK: - Manual Ad View Builder (media-hero layout)
+
+    private func buildManualAdView() -> CLXNativeAdView {
+        let adView = CLXNativeAdView()
+        adView.backgroundColor = UIColor(red: 0.08, green: 0.08, blue: 0.10, alpha: 1.0)
+        adView.layer.cornerRadius = 16
+        adView.clipsToBounds = true
+
+        let media = UIView()
+        media.tag = CLXNativeAdViewTagMediaViewContainer
+        media.clipsToBounds = true
+        media.translatesAutoresizingMaskIntoConstraints = false
+        adView.addSubview(media)
+
+        let gradientView = GradientFadeView()
+        gradientView.translatesAutoresizingMaskIntoConstraints = false
+        gradientView.isUserInteractionEnabled = false
+        adView.addSubview(gradientView)
+
+        let options = UIView()
+        options.tag = CLXNativeAdViewTagOptionsContentView
+        options.translatesAutoresizingMaskIntoConstraints = false
+        adView.addSubview(options)
+
+        let bottomBar = UIView()
+        bottomBar.translatesAutoresizingMaskIntoConstraints = false
+        adView.addSubview(bottomBar)
+
+        let icon = UIImageView()
+        icon.tag = CLXNativeAdViewTagIconImageView
+        icon.contentMode = .scaleAspectFill
+        icon.clipsToBounds = true
+        icon.layer.cornerRadius = 22
+        icon.layer.borderWidth = 2
+        icon.layer.borderColor = UIColor.white.cgColor
+        icon.translatesAutoresizingMaskIntoConstraints = false
+        bottomBar.addSubview(icon)
+
+        let titleLabel = UILabel()
+        titleLabel.tag = CLXNativeAdViewTagTitleLabel
+        titleLabel.font = .boldSystemFont(ofSize: 15)
+        titleLabel.textColor = .white
+        titleLabel.translatesAutoresizingMaskIntoConstraints = false
+        bottomBar.addSubview(titleLabel)
+
+        let advertiser = UILabel()
+        advertiser.tag = CLXNativeAdViewTagAdvertiserLabel
+        advertiser.font = .systemFont(ofSize: 10)
+        advertiser.textColor = UIColor(white: 1.0, alpha: 0.5)
+        advertiser.translatesAutoresizingMaskIntoConstraints = false
+        bottomBar.addSubview(advertiser)
+
+        let body = UILabel()
+        body.tag = CLXNativeAdViewTagBodyLabel
+        body.font = .systemFont(ofSize: 12)
+        body.textColor = UIColor(white: 1.0, alpha: 0.7)
+        body.numberOfLines = 1
+        body.translatesAutoresizingMaskIntoConstraints = false
+        bottomBar.addSubview(body)
+
+        let cta = UIButton(type: .system)
+        cta.tag = CLXNativeAdViewTagCallToActionButton
+        cta.titleLabel?.font = .boldSystemFont(ofSize: 13)
+        cta.backgroundColor = .systemGreen
+        cta.setTitleColor(.white, for: .normal)
+        cta.layer.cornerRadius = 16
+        cta.contentEdgeInsets = UIEdgeInsets(top: 0, left: 16, bottom: 0, right: 16)
+        cta.translatesAutoresizingMaskIntoConstraints = false
+        bottomBar.addSubview(cta)
+
+        NSLayoutConstraint.activate([
+            media.topAnchor.constraint(equalTo: adView.topAnchor),
+            media.leadingAnchor.constraint(equalTo: adView.leadingAnchor),
+            media.trailingAnchor.constraint(equalTo: adView.trailingAnchor),
+            media.heightAnchor.constraint(equalToConstant: 300),
+
+            gradientView.leadingAnchor.constraint(equalTo: adView.leadingAnchor),
+            gradientView.trailingAnchor.constraint(equalTo: adView.trailingAnchor),
+            gradientView.bottomAnchor.constraint(equalTo: media.bottomAnchor),
+            gradientView.heightAnchor.constraint(equalToConstant: 80),
+
+            options.topAnchor.constraint(equalTo: adView.topAnchor, constant: 8),
+            options.trailingAnchor.constraint(equalTo: adView.trailingAnchor, constant: -8),
+            options.widthAnchor.constraint(equalToConstant: 28),
+            options.heightAnchor.constraint(equalToConstant: 28),
+
+            bottomBar.topAnchor.constraint(equalTo: media.bottomAnchor, constant: 10),
+            bottomBar.leadingAnchor.constraint(equalTo: adView.leadingAnchor, constant: 12),
+            bottomBar.trailingAnchor.constraint(equalTo: adView.trailingAnchor, constant: -12),
+            bottomBar.bottomAnchor.constraint(equalTo: adView.bottomAnchor, constant: -12),
+
+            icon.topAnchor.constraint(equalTo: bottomBar.topAnchor),
+            icon.leadingAnchor.constraint(equalTo: bottomBar.leadingAnchor),
+            icon.widthAnchor.constraint(equalToConstant: 44),
+            icon.heightAnchor.constraint(equalToConstant: 44),
+
+            titleLabel.topAnchor.constraint(equalTo: bottomBar.topAnchor),
+            titleLabel.leadingAnchor.constraint(equalTo: icon.trailingAnchor, constant: 10),
+            titleLabel.trailingAnchor.constraint(equalTo: cta.leadingAnchor, constant: -8),
+
+            advertiser.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 1),
+            advertiser.leadingAnchor.constraint(equalTo: titleLabel.leadingAnchor),
+
+            body.topAnchor.constraint(equalTo: icon.bottomAnchor, constant: 8),
+            body.leadingAnchor.constraint(equalTo: bottomBar.leadingAnchor),
+            body.trailingAnchor.constraint(equalTo: bottomBar.trailingAnchor),
+            body.bottomAnchor.constraint(equalTo: bottomBar.bottomAnchor),
+
+            cta.centerYAnchor.constraint(equalTo: icon.centerYAnchor),
+            cta.trailingAnchor.constraint(equalTo: bottomBar.trailingAnchor),
+            cta.heightAnchor.constraint(equalToConstant: 32),
+        ])
+
+        return adView
+    }
+
+    // MARK: - Spotlight Ad View Builder (light card for Flow C)
+
+    private func buildSpotlightAdView() -> CLXNativeAdView {
+        let adView = CLXNativeAdView()
+        adView.backgroundColor = UIColor(red: 1.0, green: 0.97, blue: 0.93, alpha: 1.0)
+        adView.layer.cornerRadius = 16
+        adView.clipsToBounds = true
+
+        let header = UIView()
+        header.translatesAutoresizingMaskIntoConstraints = false
+        adView.addSubview(header)
+
+        let icon = UIImageView()
+        icon.tag = CLXNativeAdViewTagIconImageView
+        icon.contentMode = .scaleAspectFill
+        icon.clipsToBounds = true
+        icon.layer.cornerRadius = 8
+        icon.translatesAutoresizingMaskIntoConstraints = false
+        header.addSubview(icon)
+
+        let options = UIView()
+        options.tag = CLXNativeAdViewTagOptionsContentView
+        options.translatesAutoresizingMaskIntoConstraints = false
+        header.addSubview(options)
+
+        let titleLabel = UILabel()
+        titleLabel.tag = CLXNativeAdViewTagTitleLabel
+        titleLabel.font = .boldSystemFont(ofSize: 16)
+        titleLabel.textColor = UIColor(red: 0.2, green: 0.1, blue: 0.0, alpha: 1.0)
+        titleLabel.translatesAutoresizingMaskIntoConstraints = false
+        header.addSubview(titleLabel)
+
+        let advertiser = UILabel()
+        advertiser.tag = CLXNativeAdViewTagAdvertiserLabel
+        advertiser.font = .systemFont(ofSize: 11)
+        advertiser.textColor = UIColor(red: 0.6, green: 0.4, blue: 0.2, alpha: 1.0)
+        advertiser.translatesAutoresizingMaskIntoConstraints = false
+        header.addSubview(advertiser)
+
+        let body = UILabel()
+        body.tag = CLXNativeAdViewTagBodyLabel
+        body.font = .systemFont(ofSize: 13)
+        body.textColor = UIColor(red: 0.35, green: 0.25, blue: 0.15, alpha: 1.0)
+        body.numberOfLines = 2
+        body.translatesAutoresizingMaskIntoConstraints = false
+        adView.addSubview(body)
+
+        let media = UIView()
+        media.tag = CLXNativeAdViewTagMediaViewContainer
+        media.clipsToBounds = true
+        media.layer.cornerRadius = 12
+        media.translatesAutoresizingMaskIntoConstraints = false
+        adView.addSubview(media)
+
+        let cta = UIButton(type: .system)
+        cta.tag = CLXNativeAdViewTagCallToActionButton
+        cta.titleLabel?.font = .boldSystemFont(ofSize: 15)
+        cta.backgroundColor = .systemOrange
+        cta.setTitleColor(.white, for: .normal)
+        cta.layer.cornerRadius = 22
+        cta.translatesAutoresizingMaskIntoConstraints = false
+        adView.addSubview(cta)
+
+        let pad: CGFloat = 14
+        NSLayoutConstraint.activate([
+            header.topAnchor.constraint(equalTo: adView.topAnchor, constant: pad),
+            header.leadingAnchor.constraint(equalTo: adView.leadingAnchor, constant: pad),
+            header.trailingAnchor.constraint(equalTo: adView.trailingAnchor, constant: -pad),
+
+            icon.topAnchor.constraint(equalTo: header.topAnchor),
+            icon.leadingAnchor.constraint(equalTo: header.leadingAnchor),
+            icon.widthAnchor.constraint(equalToConstant: 44),
+            icon.heightAnchor.constraint(equalToConstant: 44),
+            icon.bottomAnchor.constraint(equalTo: header.bottomAnchor),
+
+            titleLabel.topAnchor.constraint(equalTo: header.topAnchor, constant: 2),
+            titleLabel.leadingAnchor.constraint(equalTo: icon.trailingAnchor, constant: 10),
+            titleLabel.trailingAnchor.constraint(equalTo: options.leadingAnchor, constant: -8),
+
+            advertiser.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 1),
+            advertiser.leadingAnchor.constraint(equalTo: titleLabel.leadingAnchor),
+
+            options.topAnchor.constraint(equalTo: header.topAnchor),
+            options.trailingAnchor.constraint(equalTo: header.trailingAnchor),
+            options.widthAnchor.constraint(equalToConstant: 28),
+            options.heightAnchor.constraint(equalToConstant: 28),
+
+            body.topAnchor.constraint(equalTo: header.bottomAnchor, constant: 8),
+            body.leadingAnchor.constraint(equalTo: adView.leadingAnchor, constant: pad),
+            body.trailingAnchor.constraint(equalTo: adView.trailingAnchor, constant: -pad),
+
+            media.topAnchor.constraint(equalTo: body.bottomAnchor, constant: 10),
+            media.leadingAnchor.constraint(equalTo: adView.leadingAnchor, constant: pad),
+            media.trailingAnchor.constraint(equalTo: adView.trailingAnchor, constant: -pad),
+            media.heightAnchor.constraint(equalToConstant: 280),
+
+            cta.topAnchor.constraint(equalTo: media.bottomAnchor, constant: 12),
+            cta.leadingAnchor.constraint(equalTo: adView.leadingAnchor, constant: pad),
+            cta.trailingAnchor.constraint(equalTo: adView.trailingAnchor, constant: -pad),
+            cta.heightAnchor.constraint(equalToConstant: 44),
+            cta.bottomAnchor.constraint(equalTo: adView.bottomAnchor, constant: -pad),
+        ])
+
+        return adView
+    }
+
+    // MARK: - Display
+
+    private func displayAdView(_ adView: CLXNativeAdView) {
+        nativeAdView?.removeFromSuperview()
+        nativeAdView = adView
+        adView.translatesAutoresizingMaskIntoConstraints = false
+        adContainerView.addSubview(adView)
+
+        NSLayoutConstraint.activate([
+            adView.topAnchor.constraint(equalTo: adContainerView.topAnchor),
+            adView.leadingAnchor.constraint(equalTo: adContainerView.leadingAnchor),
+            adView.trailingAnchor.constraint(equalTo: adContainerView.trailingAnchor),
+            adView.bottomAnchor.constraint(equalTo: adContainerView.bottomAnchor)
+        ])
+    }
+}
+
+// MARK: - CLXNativeAdDelegate
+
+extension NativeViewController: CLXNativeAdDelegate {
+    func didLoadNativeAd(_ nativeAdView: CLXNativeAdView?, for ad: CLXAd) {
+        DemoAppLogger.sharedInstance.logAdEvent("✅ Native didLoadNativeAd", ad: ad)
+        isLoading = false
+        loadedAd = ad
+
+        if activeFlow == .lateBinding {
+            preloadedAd = ad
+            updateStatusUI(state: .ready)
+            updateFlowBanner(text: "Step 1 done — tap 'Bind & Display'", color: .systemOrange)
+            showBindButton(true)
+            DemoAppLogger.sharedInstance.logMessage("Flow C Step 1: Ad pre-loaded — waiting for bind")
+            return
+        }
+
+        updateStatusUI(state: .ready)
+
+        if let view = nativeAdView {
+            displayAdView(view)
+            updateFlowBanner(text: "MANUAL — Custom publisher layout", color: .systemBlue)
+        } else if let nativeAd = ad.nativeAd {
+            let templateView = CLXNativeAdView(from: nativeAd)
+            ensureLoader().renderNativeAdView(templateView, with: ad)
+            displayAdView(templateView)
+            updateFlowBanner(text: "TEMPLATE — SDK auto-generated view", color: .systemGreen)
+        }
+    }
+
+    func didFailToLoadNativeAd(forAdUnitIdentifier adUnitId: String, error: CLXError) {
+        DemoAppLogger.sharedInstance.logMessage("❌ Native failed (\(adUnitId)) - \(error.localizedDescription)")
+        isLoading = false
+        updateStatusUI(state: .noAd)
+        flowBanner.text = nil
+
+        DispatchQueue.main.async { [weak self] in
+            let msg = (error as NSError).detailedDemoDescription
+            self?.showAlert(title: "Native Load Failed", message: msg)
+        }
+    }
+
+    func didClickNativeAd(_ ad: CLXAd) {
+        DemoAppLogger.sharedInstance.logAdEvent("👆 Native didClickNativeAd", ad: ad)
+    }
+
+    func didExpireNativeAd(_ ad: CLXAd) {
+        DemoAppLogger.sharedInstance.logAdEvent("⏰ Native didExpireNativeAd", ad: ad)
+        resetAdState()
+    }
+
+    func didCloseNativeAd(_ ad: CLXAd) {
+        DemoAppLogger.sharedInstance.logAdEvent("🚪 Native didCloseNativeAd — user reported/hid ad via AdChoices", ad: ad)
+    }
+}
+
+// MARK: - CLXAdRevenueDelegate
+
+extension NativeViewController: CLXAdRevenueDelegate {
+    func didPayRevenue(for ad: CLXAd) {
+        DemoAppLogger.sharedInstance.logAdEvent("💰 Native didPayRevenueForAd", ad: ad)
+    }
+}
+
+// MARK: - GradientFadeView
+
+private class GradientFadeView: UIView {
+    override class var layerClass: AnyClass { CAGradientLayer.self }
+
+    override func didMoveToSuperview() {
+        super.didMoveToSuperview()
+        guard let gradient = layer as? CAGradientLayer else { return }
+        gradient.colors = [UIColor.clear.cgColor,
+                           UIColor(red: 0.08, green: 0.08, blue: 0.10, alpha: 0.9).cgColor]
+    }
+}

--- a/demo-app-swift/CloudXSwiftRemotePods/Views/Ad/NativeViewController.swift
+++ b/demo-app-swift/CloudXSwiftRemotePods/Views/Ad/NativeViewController.swift
@@ -228,6 +228,7 @@ class NativeViewController: BaseAdViewController {
             return
         }
         resetAdState()
+        receivedCallbacks = []
         activeFlow = .manual
 
         let adView = buildManualAdView()
@@ -256,6 +257,7 @@ class NativeViewController: BaseAdViewController {
             return
         }
         resetAdState()
+        receivedCallbacks = []
         activeFlow = .lateBinding
         isLoading = true
         updateStatusUI(state: .loading)

--- a/demo-app-swift/CloudXSwiftRemotePods/Views/Ad/NativeViewController.swift
+++ b/demo-app-swift/CloudXSwiftRemotePods/Views/Ad/NativeViewController.swift
@@ -202,12 +202,17 @@ class NativeViewController: BaseAdViewController {
 
     // MARK: - Flow A: Template
 
+    @objc func loadNativeAd() {
+        loadTemplate()
+    }
+
     private func loadTemplate() {
         guard !isLoading else {
             showAlert(title: "Info", message: "Native ad is already loading.")
             return
         }
         resetAdState()
+        receivedCallbacks = []
         activeFlow = .template
         isLoading = true
         updateStatusUI(state: .loading)
@@ -526,6 +531,8 @@ class NativeViewController: BaseAdViewController {
         return adView
     }
 
+    override func adViewForClickTesting() -> UIView? { nativeAdView }
+
     // MARK: - Display
 
     private func displayAdView(_ adView: CLXNativeAdView) {
@@ -549,6 +556,7 @@ extension NativeViewController: CLXNativeAdDelegate {
     func didLoadNativeAd(_ nativeAdView: CLXNativeAdView?, for ad: CLXAd) {
         DemoAppLogger.sharedInstance.logAdEvent("✅ Native didLoadNativeAd", ad: ad)
         isLoading = false
+        receivedCallbacks.insert(.loaded)
         loadedAd = ad
 
         if activeFlow == .lateBinding {
@@ -586,6 +594,7 @@ extension NativeViewController: CLXNativeAdDelegate {
     }
 
     func didClickNativeAd(_ ad: CLXAd) {
+        receivedCallbacks.insert(.clicked)
         DemoAppLogger.sharedInstance.logAdEvent("👆 Native didClickNativeAd", ad: ad)
     }
 
@@ -603,6 +612,7 @@ extension NativeViewController: CLXNativeAdDelegate {
 
 extension NativeViewController: CLXAdRevenueDelegate {
     func didPayRevenue(for ad: CLXAd) {
+        receivedCallbacks.insert(.revenueReceived)
         DemoAppLogger.sharedInstance.logAdEvent("💰 Native didPayRevenueForAd", ad: ad)
     }
 }

--- a/demo-app-swift/CloudXSwiftRemotePods/Views/Ad/ReelsFeedViewController.swift
+++ b/demo-app-swift/CloudXSwiftRemotePods/Views/Ad/ReelsFeedViewController.swift
@@ -1,0 +1,749 @@
+import UIKit
+import CloudXCore
+
+private let kReelsAdCount = 5
+
+private class ReelsAdItem {
+    var loader: CLXNativeAdLoader?
+    var ad: CLXAd?
+    var nativeAd: CLXNativeAd?
+    var isLoading = false
+    var isLoaded = false
+    var isFailed = false
+    var hideControls = false
+    var isImagePlaceholder = false
+
+    init(loader: CLXNativeAdLoader?) {
+        self.loader = loader
+    }
+}
+
+// MARK: - ReelsCell
+
+private class ReelsCell: UICollectionViewCell {
+    let nativeAdView = CLXNativeAdView()
+    let mediaContainer = UIView()
+    let gradientContainer = UIView()
+    let reelsTitleLabel = UILabel()
+    let reelsBodyLabel = UILabel()
+    let reelsAdvertiserLabel = UILabel()
+    let ctaButton = UIButton(type: .system)
+    let optionsContainer = UIView()
+    let iconContainer = UIView()
+    let reelsIconImageView = UIImageView()
+    let spinner = UIActivityIndicatorView(style: .large)
+    let slotLabel = UILabel()
+    let videoBadge = UILabel()
+    let durationLabel = UILabel()
+    let placeholderImageView = UIImageView()
+    private var gradient: CAGradientLayer?
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        contentView.backgroundColor = .black
+        contentView.clipsToBounds = true
+        buildSubviews()
+    }
+
+    required init?(coder: NSCoder) { fatalError() }
+
+    private func buildSubviews() {
+        nativeAdView.translatesAutoresizingMaskIntoConstraints = false
+        nativeAdView.backgroundColor = .clear
+        contentView.addSubview(nativeAdView)
+
+        mediaContainer.translatesAutoresizingMaskIntoConstraints = false
+        mediaContainer.clipsToBounds = true
+        nativeAdView.addSubview(mediaContainer)
+
+        gradientContainer.translatesAutoresizingMaskIntoConstraints = false
+        gradientContainer.isUserInteractionEnabled = false
+        nativeAdView.addSubview(gradientContainer)
+
+        iconContainer.translatesAutoresizingMaskIntoConstraints = false
+        iconContainer.clipsToBounds = true
+        iconContainer.layer.cornerRadius = 20
+        nativeAdView.addSubview(iconContainer)
+
+        reelsIconImageView.contentMode = .scaleAspectFill
+        reelsIconImageView.clipsToBounds = true
+        reelsIconImageView.translatesAutoresizingMaskIntoConstraints = false
+        iconContainer.addSubview(reelsIconImageView)
+
+        reelsTitleLabel.font = .boldSystemFont(ofSize: 17)
+        reelsTitleLabel.textColor = .white
+        reelsTitleLabel.numberOfLines = 2
+        reelsTitleLabel.translatesAutoresizingMaskIntoConstraints = false
+        nativeAdView.addSubview(reelsTitleLabel)
+
+        reelsAdvertiserLabel.font = .systemFont(ofSize: 13)
+        reelsAdvertiserLabel.textColor = UIColor(white: 1.0, alpha: 0.7)
+        reelsAdvertiserLabel.translatesAutoresizingMaskIntoConstraints = false
+        nativeAdView.addSubview(reelsAdvertiserLabel)
+
+        reelsBodyLabel.font = .systemFont(ofSize: 14)
+        reelsBodyLabel.textColor = UIColor(white: 1.0, alpha: 0.9)
+        reelsBodyLabel.numberOfLines = 2
+        reelsBodyLabel.translatesAutoresizingMaskIntoConstraints = false
+        nativeAdView.addSubview(reelsBodyLabel)
+
+        ctaButton.titleLabel?.font = .boldSystemFont(ofSize: 15)
+        ctaButton.backgroundColor = .white
+        ctaButton.setTitleColor(.black, for: .normal)
+        ctaButton.layer.cornerRadius = 22
+        ctaButton.translatesAutoresizingMaskIntoConstraints = false
+        nativeAdView.addSubview(ctaButton)
+
+        optionsContainer.translatesAutoresizingMaskIntoConstraints = false
+        nativeAdView.addSubview(optionsContainer)
+
+        spinner.color = .white
+        spinner.translatesAutoresizingMaskIntoConstraints = false
+        spinner.hidesWhenStopped = true
+        nativeAdView.addSubview(spinner)
+
+        slotLabel.font = .monospacedSystemFont(ofSize: 11, weight: .medium)
+        slotLabel.textColor = UIColor(white: 1.0, alpha: 0.5)
+        slotLabel.translatesAutoresizingMaskIntoConstraints = false
+        nativeAdView.addSubview(slotLabel)
+
+        videoBadge.font = .monospacedSystemFont(ofSize: 10, weight: .bold)
+        videoBadge.textColor = .white
+        videoBadge.textAlignment = .center
+        videoBadge.layer.cornerRadius = 4
+        videoBadge.clipsToBounds = true
+        videoBadge.translatesAutoresizingMaskIntoConstraints = false
+        videoBadge.isHidden = true
+        nativeAdView.addSubview(videoBadge)
+
+        durationLabel.font = .monospacedDigitSystemFont(ofSize: 13, weight: .semibold)
+        durationLabel.textColor = .white
+        durationLabel.textAlignment = .center
+        durationLabel.backgroundColor = UIColor.black.withAlphaComponent(0.6)
+        durationLabel.layer.cornerRadius = 4
+        durationLabel.clipsToBounds = true
+        durationLabel.translatesAutoresizingMaskIntoConstraints = false
+        durationLabel.isHidden = true
+        nativeAdView.addSubview(durationLabel)
+
+        placeholderImageView.contentMode = .scaleAspectFill
+        placeholderImageView.clipsToBounds = true
+        placeholderImageView.translatesAutoresizingMaskIntoConstraints = false
+        placeholderImageView.isHidden = true
+        nativeAdView.insertSubview(placeholderImageView, aboveSubview: mediaContainer)
+
+        nativeAdView.mediaContentView = mediaContainer
+        nativeAdView.callToActionButton = ctaButton
+        nativeAdView.titleLabel = reelsTitleLabel
+        nativeAdView.bodyLabel = reelsBodyLabel
+        nativeAdView.advertiserLabel = reelsAdvertiserLabel
+        nativeAdView.optionsContentView = optionsContainer
+        nativeAdView.iconContentView = iconContainer
+        nativeAdView.iconImageView = reelsIconImageView
+
+        let pad: CGFloat = 16
+        NSLayoutConstraint.activate([
+            nativeAdView.topAnchor.constraint(equalTo: contentView.topAnchor),
+            nativeAdView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+            nativeAdView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+            nativeAdView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
+
+            mediaContainer.topAnchor.constraint(equalTo: nativeAdView.topAnchor),
+            mediaContainer.leadingAnchor.constraint(equalTo: nativeAdView.leadingAnchor),
+            mediaContainer.trailingAnchor.constraint(equalTo: nativeAdView.trailingAnchor),
+            mediaContainer.bottomAnchor.constraint(equalTo: nativeAdView.bottomAnchor),
+
+            gradientContainer.leadingAnchor.constraint(equalTo: nativeAdView.leadingAnchor),
+            gradientContainer.trailingAnchor.constraint(equalTo: nativeAdView.trailingAnchor),
+            gradientContainer.bottomAnchor.constraint(equalTo: nativeAdView.bottomAnchor),
+            gradientContainer.heightAnchor.constraint(equalToConstant: 280),
+
+            ctaButton.leadingAnchor.constraint(equalTo: nativeAdView.leadingAnchor, constant: pad),
+            ctaButton.trailingAnchor.constraint(equalTo: nativeAdView.trailingAnchor, constant: -pad),
+            ctaButton.bottomAnchor.constraint(equalTo: nativeAdView.safeAreaLayoutGuide.bottomAnchor, constant: -pad),
+            ctaButton.heightAnchor.constraint(equalToConstant: 44),
+
+            reelsBodyLabel.leadingAnchor.constraint(equalTo: nativeAdView.leadingAnchor, constant: pad),
+            reelsBodyLabel.trailingAnchor.constraint(equalTo: nativeAdView.trailingAnchor, constant: -pad),
+            reelsBodyLabel.bottomAnchor.constraint(equalTo: ctaButton.topAnchor, constant: -12),
+
+            iconContainer.leadingAnchor.constraint(equalTo: nativeAdView.leadingAnchor, constant: pad),
+            iconContainer.widthAnchor.constraint(equalToConstant: 40),
+            iconContainer.heightAnchor.constraint(equalToConstant: 40),
+            iconContainer.bottomAnchor.constraint(equalTo: reelsBodyLabel.topAnchor, constant: -10),
+
+            reelsIconImageView.topAnchor.constraint(equalTo: iconContainer.topAnchor),
+            reelsIconImageView.leadingAnchor.constraint(equalTo: iconContainer.leadingAnchor),
+            reelsIconImageView.trailingAnchor.constraint(equalTo: iconContainer.trailingAnchor),
+            reelsIconImageView.bottomAnchor.constraint(equalTo: iconContainer.bottomAnchor),
+
+            reelsTitleLabel.leadingAnchor.constraint(equalTo: iconContainer.trailingAnchor, constant: 10),
+            reelsTitleLabel.trailingAnchor.constraint(equalTo: nativeAdView.trailingAnchor, constant: -pad),
+            reelsTitleLabel.centerYAnchor.constraint(equalTo: iconContainer.centerYAnchor, constant: -8),
+
+            reelsAdvertiserLabel.leadingAnchor.constraint(equalTo: reelsTitleLabel.leadingAnchor),
+            reelsAdvertiserLabel.trailingAnchor.constraint(equalTo: reelsTitleLabel.trailingAnchor),
+            reelsAdvertiserLabel.topAnchor.constraint(equalTo: reelsTitleLabel.bottomAnchor, constant: 2),
+
+            optionsContainer.topAnchor.constraint(equalTo: nativeAdView.safeAreaLayoutGuide.topAnchor, constant: 8),
+            optionsContainer.trailingAnchor.constraint(equalTo: nativeAdView.trailingAnchor, constant: -pad),
+            optionsContainer.widthAnchor.constraint(equalToConstant: 30),
+            optionsContainer.heightAnchor.constraint(equalToConstant: 30),
+
+            spinner.centerXAnchor.constraint(equalTo: nativeAdView.centerXAnchor),
+            spinner.centerYAnchor.constraint(equalTo: nativeAdView.centerYAnchor),
+
+            slotLabel.topAnchor.constraint(equalTo: nativeAdView.safeAreaLayoutGuide.topAnchor, constant: 8),
+            slotLabel.leadingAnchor.constraint(equalTo: nativeAdView.leadingAnchor, constant: pad),
+
+            videoBadge.leadingAnchor.constraint(equalTo: slotLabel.trailingAnchor, constant: 8),
+            videoBadge.centerYAnchor.constraint(equalTo: slotLabel.centerYAnchor),
+            videoBadge.heightAnchor.constraint(equalToConstant: 18),
+
+            durationLabel.trailingAnchor.constraint(equalTo: nativeAdView.trailingAnchor, constant: -pad),
+            durationLabel.bottomAnchor.constraint(equalTo: iconContainer.topAnchor, constant: -16),
+            durationLabel.heightAnchor.constraint(equalToConstant: 24),
+
+            placeholderImageView.topAnchor.constraint(equalTo: nativeAdView.topAnchor),
+            placeholderImageView.leadingAnchor.constraint(equalTo: nativeAdView.leadingAnchor),
+            placeholderImageView.trailingAnchor.constraint(equalTo: nativeAdView.trailingAnchor),
+            placeholderImageView.bottomAnchor.constraint(equalTo: nativeAdView.bottomAnchor),
+        ])
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        if gradient == nil {
+            let g = CAGradientLayer()
+            g.colors = [UIColor.clear.cgColor, UIColor(white: 0, alpha: 0.8).cgColor]
+            g.locations = [0.0, 1.0]
+            gradientContainer.layer.insertSublayer(g, at: 0)
+            gradient = g
+        }
+        gradient?.frame = gradientContainer.bounds
+    }
+
+    func configure(with item: ReelsAdItem, at index: Int) {
+        slotLabel.text = "\(index + 1) / \(kReelsAdCount)"
+
+        if item.isImagePlaceholder {
+            spinner.stopAnimating()
+            placeholderImageView.isHidden = false
+            placeholderImageView.image = UIImage(systemName: "photo.artframe")
+            placeholderImageView.tintColor = UIColor(white: 1.0, alpha: 0.15)
+            placeholderImageView.contentMode = .scaleAspectFit
+            mediaContainer.isHidden = true
+            setOverlayVisible(true)
+            reelsTitleLabel.text = "Sample Static Ad"
+            reelsBodyLabel.text = "This reel demonstrates the IMAGE badge path"
+            reelsAdvertiserLabel.text = "Demo Advertiser"
+            ctaButton.setTitle("Learn More", for: .normal)
+            videoBadge.isHidden = false
+            videoBadge.text = " IMAGE "
+            videoBadge.backgroundColor = UIColor.systemBlue.withAlphaComponent(0.7)
+            durationLabel.isHidden = true
+        } else if item.isLoaded, let nativeAd = item.nativeAd {
+            spinner.stopAnimating()
+            placeholderImageView.isHidden = true
+            mediaContainer.isHidden = false
+            setOverlayVisible(!item.hideControls)
+            updateVideoBadge(with: nativeAd)
+        } else if item.isFailed {
+            spinner.stopAnimating()
+            placeholderImageView.isHidden = true
+            mediaContainer.isHidden = false
+            setOverlayVisible(false)
+            reelsTitleLabel.text = "Load Failed"
+            reelsTitleLabel.isHidden = false
+            reelsBodyLabel.isHidden = true
+            videoBadge.isHidden = true
+            durationLabel.isHidden = true
+        } else {
+            spinner.startAnimating()
+            placeholderImageView.isHidden = true
+            mediaContainer.isHidden = false
+            setOverlayVisible(false)
+            videoBadge.isHidden = true
+            durationLabel.isHidden = true
+        }
+    }
+
+    private func updateVideoBadge(with nativeAd: CLXNativeAd) {
+        videoBadge.isHidden = false
+        if nativeAd.isVideoContent {
+            videoBadge.text = " VIDEO "
+            videoBadge.backgroundColor = UIColor.systemRed.withAlphaComponent(0.85)
+
+            if nativeAd.videoDuration > 0 {
+                let totalSeconds = Int(nativeAd.videoDuration)
+                let minutes = totalSeconds / 60
+                let seconds = totalSeconds % 60
+                durationLabel.text = " \(minutes):\(String(format: "%02d", seconds)) "
+                durationLabel.isHidden = false
+            } else {
+                durationLabel.isHidden = true
+            }
+        } else {
+            videoBadge.text = " STATIC "
+            videoBadge.backgroundColor = UIColor.systemBlue.withAlphaComponent(0.7)
+            durationLabel.isHidden = true
+        }
+    }
+
+    private func setOverlayVisible(_ visible: Bool) {
+        reelsTitleLabel.isHidden = !visible
+        reelsAdvertiserLabel.isHidden = !visible
+        reelsBodyLabel.isHidden = !visible
+        ctaButton.isHidden = !visible
+        gradientContainer.isHidden = !visible
+        iconContainer.isHidden = !visible
+    }
+
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        spinner.stopAnimating()
+        nativeAdView.prepareForReuse()
+        placeholderImageView.isHidden = true
+        placeholderImageView.image = nil
+        mediaContainer.isHidden = false
+        iconContainer.addSubview(reelsIconImageView)
+        reelsIconImageView.image = nil
+        videoBadge.isHidden = true
+        durationLabel.isHidden = true
+    }
+}
+
+// MARK: - ReelsFeedViewController
+
+class ReelsFeedViewController: UIViewController, UICollectionViewDataSource,
+                                UICollectionViewDelegateFlowLayout,
+                                CLXNativeAdDelegate, CLXAdRevenueDelegate {
+
+    private var collectionView: UICollectionView!
+    private var items: [ReelsAdItem] = []
+    private var nextLoadIndex = 0
+    private let settings = UserDefaultsSettings.shared
+    private var settingsPanel: UIView!
+    private var fullScreenSwitch: UISwitch!
+    private var unmutedSwitch: UISwitch!
+    private var hideControlsSwitch: UISwitch!
+    private var settingsPanelVisible = false
+    private var gearButton: UIButton!
+    private var settingsBadgesStack: UIStackView!
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        title = "Reels Feed"
+        view.backgroundColor = .black
+        setupCollectionView()
+        setupAppLogsButton()
+        setupSettingsPanel()
+        createItems()
+        loadNextAd()
+    }
+
+    deinit {
+        items.forEach { $0.loader?.destroy() }
+    }
+
+    override var preferredStatusBarStyle: UIStatusBarStyle { .lightContent }
+
+    // MARK: - Setup
+
+    private func setupCollectionView() {
+        let layout = UICollectionViewFlowLayout()
+        layout.scrollDirection = .vertical
+        layout.minimumLineSpacing = 0
+        layout.minimumInteritemSpacing = 0
+
+        collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
+        collectionView.translatesAutoresizingMaskIntoConstraints = false
+        collectionView.dataSource = self
+        collectionView.delegate = self
+        collectionView.isPagingEnabled = true
+        collectionView.showsVerticalScrollIndicator = false
+        collectionView.backgroundColor = .black
+        collectionView.contentInsetAdjustmentBehavior = .never
+        collectionView.register(ReelsCell.self, forCellWithReuseIdentifier: "ReelsCell")
+        view.addSubview(collectionView)
+
+        NSLayoutConstraint.activate([
+            collectionView.topAnchor.constraint(equalTo: view.topAnchor),
+            collectionView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            collectionView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            collectionView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+        ])
+    }
+
+    private func setupAppLogsButton() {
+        let logsButton = UIButton(type: .system)
+        logsButton.setTitle("App Logs", for: .normal)
+        logsButton.titleLabel?.font = .systemFont(ofSize: 14, weight: .medium)
+        logsButton.backgroundColor = UIColor.systemOrange.withAlphaComponent(0.9)
+        logsButton.setTitleColor(.white, for: .normal)
+        logsButton.layer.cornerRadius = 6
+        logsButton.translatesAutoresizingMaskIntoConstraints = false
+        logsButton.addTarget(self, action: #selector(showLogsModal), for: .touchUpInside)
+        view.addSubview(logsButton)
+
+        NSLayoutConstraint.activate([
+            logsButton.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 8),
+            logsButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -12),
+            logsButton.widthAnchor.constraint(equalToConstant: 90),
+            logsButton.heightAnchor.constraint(equalToConstant: 30),
+        ])
+    }
+
+    @objc private func showLogsModal() {
+        let logsModal = LogsModalViewController(title: "Logs")
+        present(logsModal, animated: true)
+    }
+
+    private func setupSettingsPanel() {
+        gearButton = UIButton(type: .system)
+        let iconConfig = UIImage.SymbolConfiguration(pointSize: 12, weight: .medium)
+        let gearIcon = UIImage(systemName: "slider.horizontal.3", withConfiguration: iconConfig)
+        gearButton.setImage(gearIcon, for: .normal)
+        gearButton.setTitle(" Video Config", for: .normal)
+        gearButton.titleLabel?.font = .systemFont(ofSize: 12, weight: .semibold)
+        gearButton.tintColor = .white
+        gearButton.backgroundColor = UIColor.black.withAlphaComponent(0.6)
+        gearButton.layer.cornerRadius = 14
+        gearButton.contentEdgeInsets = UIEdgeInsets(top: 6, left: 10, bottom: 6, right: 12)
+        gearButton.translatesAutoresizingMaskIntoConstraints = false
+        gearButton.addTarget(self, action: #selector(toggleSettingsPanel), for: .touchUpInside)
+        view.addSubview(gearButton)
+
+        settingsBadgesStack = UIStackView()
+        settingsBadgesStack.axis = .horizontal
+        settingsBadgesStack.spacing = 4
+        settingsBadgesStack.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(settingsBadgesStack)
+
+        let blurView = UIVisualEffectView(effect: UIBlurEffect(style: .dark))
+        blurView.layer.cornerRadius = 12
+        blurView.clipsToBounds = true
+        blurView.translatesAutoresizingMaskIntoConstraints = false
+
+        settingsPanel = UIView()
+        settingsPanel.translatesAutoresizingMaskIntoConstraints = false
+        settingsPanel.alpha = 0
+        settingsPanel.isHidden = true
+        view.addSubview(settingsPanel)
+
+        settingsPanel.addSubview(blurView)
+        NSLayoutConstraint.activate([
+            blurView.topAnchor.constraint(equalTo: settingsPanel.topAnchor),
+            blurView.leadingAnchor.constraint(equalTo: settingsPanel.leadingAnchor),
+            blurView.trailingAnchor.constraint(equalTo: settingsPanel.trailingAnchor),
+            blurView.bottomAnchor.constraint(equalTo: settingsPanel.bottomAnchor),
+        ])
+
+        let header = UILabel()
+        header.text = "Video Config"
+        header.font = .boldSystemFont(ofSize: 14)
+        header.textColor = .white
+
+        fullScreenSwitch = UISwitch()
+        fullScreenSwitch.isOn = true
+        fullScreenSwitch.transform = CGAffineTransform(scaleX: 0.7, y: 0.7)
+
+        unmutedSwitch = UISwitch()
+        unmutedSwitch.isOn = true
+        unmutedSwitch.transform = CGAffineTransform(scaleX: 0.7, y: 0.7)
+
+        hideControlsSwitch = UISwitch()
+        hideControlsSwitch.isOn = true
+        hideControlsSwitch.transform = CGAffineTransform(scaleX: 0.7, y: 0.7)
+
+        let row1 = settingsRow(label: "Disable Fullscreen", toggle: fullScreenSwitch)
+        let row2 = settingsRow(label: "Start Unmuted", toggle: unmutedSwitch)
+        let row3 = settingsRow(label: "Hide Controls", toggle: hideControlsSwitch)
+
+        let reloadButton = UIButton(type: .system)
+        reloadButton.setTitle("Reload Ads", for: .normal)
+        reloadButton.titleLabel?.font = .boldSystemFont(ofSize: 13)
+        reloadButton.backgroundColor = .systemBlue
+        reloadButton.setTitleColor(.white, for: .normal)
+        reloadButton.layer.cornerRadius = 8
+        reloadButton.translatesAutoresizingMaskIntoConstraints = false
+        reloadButton.addTarget(self, action: #selector(reloadAdsWithSettings), for: .touchUpInside)
+        reloadButton.heightAnchor.constraint(equalToConstant: 32).isActive = true
+
+        let disclaimer = UILabel()
+        disclaimer.text = "Requires FAN SDK 6.21.1+ for Meta native ads"
+        disclaimer.font = .italicSystemFont(ofSize: 9)
+        disclaimer.textColor = UIColor(white: 1.0, alpha: 0.45)
+        disclaimer.numberOfLines = 0
+        disclaimer.textAlignment = .center
+
+        let stack = UIStackView(arrangedSubviews: [header, row1, row2, row3, reloadButton, disclaimer])
+        stack.axis = .vertical
+        stack.spacing = 8
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        settingsPanel.addSubview(stack)
+
+        NSLayoutConstraint.activate([
+            gearButton.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 44),
+            gearButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -12),
+            gearButton.heightAnchor.constraint(equalToConstant: 28),
+
+            settingsBadgesStack.topAnchor.constraint(equalTo: gearButton.bottomAnchor, constant: 6),
+            settingsBadgesStack.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -12),
+
+            settingsPanel.topAnchor.constraint(equalTo: settingsBadgesStack.bottomAnchor, constant: 6),
+            settingsPanel.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -12),
+            settingsPanel.widthAnchor.constraint(equalToConstant: 220),
+
+            stack.topAnchor.constraint(equalTo: settingsPanel.topAnchor, constant: 12),
+            stack.leadingAnchor.constraint(equalTo: settingsPanel.leadingAnchor, constant: 12),
+            stack.trailingAnchor.constraint(equalTo: settingsPanel.trailingAnchor, constant: -12),
+            stack.bottomAnchor.constraint(equalTo: settingsPanel.bottomAnchor, constant: -12),
+        ])
+
+        updateSettingsBadges()
+    }
+
+    private func settingsRow(label text: String, toggle: UISwitch) -> UIStackView {
+        let label = UILabel()
+        label.text = text
+        label.font = .systemFont(ofSize: 12, weight: .medium)
+        label.textColor = UIColor(white: 1.0, alpha: 0.9)
+        let row = UIStackView(arrangedSubviews: [label, toggle])
+        row.axis = .horizontal
+        row.alignment = .center
+        row.distribution = .equalSpacing
+        return row
+    }
+
+    private func updateSettingsBadges() {
+        settingsBadgesStack.arrangedSubviews.forEach { $0.removeFromSuperview() }
+
+        let disableFS = fullScreenSwitch?.isOn ?? true
+        let unmuted   = unmutedSwitch?.isOn ?? true
+        let hideCtrl  = hideControlsSwitch?.isOn ?? true
+
+        if disableFS  { settingsBadgesStack.addArrangedSubview(makeBadge(text: "No FS", color: .systemPurple)) }
+        if unmuted    { settingsBadgesStack.addArrangedSubview(makeBadge(text: "Unmuted", color: .systemGreen)) }
+        if hideCtrl   { settingsBadgesStack.addArrangedSubview(makeBadge(text: "No Ctrl", color: .systemOrange)) }
+    }
+
+    private func makeBadge(text: String, color: UIColor) -> UILabel {
+        let badge = UILabel()
+        badge.text = "  \(text)  "
+        badge.font = .systemFont(ofSize: 9, weight: .bold)
+        badge.textColor = .white
+        badge.backgroundColor = color.withAlphaComponent(0.8)
+        badge.layer.cornerRadius = 8
+        badge.clipsToBounds = true
+        badge.translatesAutoresizingMaskIntoConstraints = false
+        badge.heightAnchor.constraint(equalToConstant: 16).isActive = true
+        return badge
+    }
+
+    @objc private func toggleSettingsPanel() {
+        settingsPanelVisible.toggle()
+        if settingsPanelVisible {
+            settingsPanel.isHidden = false
+            UIView.animate(withDuration: 0.25) { self.settingsPanel.alpha = 1.0 }
+        } else {
+            UIView.animate(withDuration: 0.2, animations: {
+                self.settingsPanel.alpha = 0
+            }, completion: { _ in self.settingsPanel.isHidden = true })
+        }
+    }
+
+    @objc private func reloadAdsWithSettings() {
+        items.forEach { $0.loader?.destroy() }
+        items.removeAll()
+        nextLoadIndex = 0
+
+        let hideCtrl = hideControlsSwitch.isOn
+        for i in 0..<kReelsAdCount {
+            if i % 2 == 1 {
+                let item = ReelsAdItem(loader: nil)
+                item.isImagePlaceholder = true
+                item.isLoaded = true
+                items.append(item)
+            } else {
+                let loader = CloudXCore.shared.createNativeAdLoader(adUnitIdentifier: adUnitId)
+                loader.nativeAdDelegate = self
+                loader.revenueDelegate = self
+                loader.placement = "reels_slot_\(i)"
+                loader.disableVideoFullScreen = fullScreenSwitch.isOn
+                loader.startVideoUnmuted = unmutedSwitch.isOn
+                loader.hideVideoMediaControls = hideCtrl
+                let item = ReelsAdItem(loader: loader)
+                item.hideControls = hideCtrl
+                items.append(item)
+            }
+        }
+
+        collectionView.reloadData()
+        loadNextAd()
+        toggleSettingsPanel()
+        updateSettingsBadges()
+
+        DemoAppLogger.sharedInstance.logMessage("🔄 Reels reloading with: fullscreen=\(fullScreenSwitch.isOn ? "OFF" : "ON"), unmuted=\(unmutedSwitch.isOn ? "YES" : "NO"), hideControls=\(hideControlsSwitch.isOn ? "YES" : "NO")")
+    }
+
+    private var adUnitId: String {
+        let id = CLXDemoConfigManager.sharedManager.currentConfig.nativeAdUnitId
+        return settings.nativeMediumAdUnitId.isEmpty ? id : settings.nativeMediumAdUnitId
+    }
+
+    private func createItems() {
+        let disableFS = fullScreenSwitch?.isOn ?? true
+        let unmuted = unmutedSwitch?.isOn ?? true
+        let hideCtrl = hideControlsSwitch?.isOn ?? true
+
+        for i in 0..<kReelsAdCount {
+            if i % 2 == 1 {
+                let item = ReelsAdItem(loader: nil)
+                item.isImagePlaceholder = true
+                item.isLoaded = true
+                items.append(item)
+            } else {
+                let loader = CloudXCore.shared.createNativeAdLoader(adUnitIdentifier: adUnitId)
+                loader.nativeAdDelegate = self
+                loader.revenueDelegate = self
+                loader.placement = "reels_slot_\(i)"
+                loader.disableVideoFullScreen = disableFS
+                loader.startVideoUnmuted = unmuted
+                loader.hideVideoMediaControls = hideCtrl
+                let item = ReelsAdItem(loader: loader)
+                item.hideControls = hideCtrl
+                items.append(item)
+            }
+        }
+    }
+
+    // MARK: - Sequential Loading
+
+    private func loadNextAd() {
+        while nextLoadIndex < kReelsAdCount && items[nextLoadIndex].isImagePlaceholder {
+            nextLoadIndex += 1
+        }
+        guard nextLoadIndex < kReelsAdCount else { return }
+        let item = items[nextLoadIndex]
+        item.isLoading = true
+        item.loader?.loadAd()
+    }
+
+    // MARK: - CLXNativeAdDelegate
+
+    func didLoadNativeAd(_ nativeAdView: CLXNativeAdView?, for ad: CLXAd) {
+        let idx = nextLoadIndex
+        guard idx < kReelsAdCount else { return }
+
+        let item = items[idx]
+        item.isLoading = false
+        item.isLoaded = true
+        item.ad = ad
+        item.nativeAd = ad.nativeAd
+
+        let creativeType = ad.nativeAd?.isVideoContent == true ? "video" : "static"
+        let duration = ad.nativeAd?.videoDuration ?? 0
+        DemoAppLogger.sharedInstance.logAdEvent("✅ Reels didLoadNativeAd (slot \(idx), \(creativeType), duration=\(String(format: "%.1f", duration))s)", ad: ad)
+        collectionView.reloadItems(at: [IndexPath(item: idx, section: 0)])
+
+        nextLoadIndex += 1
+        loadNextAd()
+    }
+
+    func didFailToLoadNativeAd(forAdUnitIdentifier adUnitId: String, error: CLXError) {
+        let idx = nextLoadIndex
+        guard idx < kReelsAdCount else { return }
+
+        let item = items[idx]
+        item.isLoading = false
+        item.isFailed = true
+
+        DemoAppLogger.sharedInstance.logMessage("❌ Reels didFailToLoadNativeAd (slot \(idx)): \(error.localizedDescription)")
+        collectionView.reloadItems(at: [IndexPath(item: idx, section: 0)])
+
+        nextLoadIndex += 1
+        loadNextAd()
+    }
+
+    func didClickNativeAd(_ ad: CLXAd) {
+        DemoAppLogger.sharedInstance.logAdEvent("👆 Reels didClickNativeAd", ad: ad)
+    }
+
+    func didExpireNativeAd(_ ad: CLXAd) {
+        DemoAppLogger.sharedInstance.logAdEvent("⏰ Reels didExpireNativeAd", ad: ad)
+    }
+
+    func didCloseNativeAd(_ ad: CLXAd) {
+        DemoAppLogger.sharedInstance.logAdEvent("🚪 Reels didCloseNativeAd — user reported/hid ad via AdChoices", ad: ad)
+
+        let closedIdx = items.firstIndex(where: { $0.ad === ad })
+        showDismissToast()
+
+        if let idx = closedIdx, idx + 1 < kReelsAdCount {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.8) { [weak self] in
+                guard let self else { return }
+                let next = IndexPath(item: idx + 1, section: 0)
+                self.collectionView.scrollToItem(at: next, at: .centeredVertically, animated: true)
+            }
+        }
+    }
+
+    private func showDismissToast() {
+        let toast = UILabel()
+        toast.text = "  Ad reported by user — moving to next  "
+        toast.font = .systemFont(ofSize: 13, weight: .medium)
+        toast.textColor = .white
+        toast.backgroundColor = UIColor.black.withAlphaComponent(0.75)
+        toast.textAlignment = .center
+        toast.layer.cornerRadius = 16
+        toast.clipsToBounds = true
+        toast.translatesAutoresizingMaskIntoConstraints = false
+        toast.alpha = 0
+        view.addSubview(toast)
+
+        NSLayoutConstraint.activate([
+            toast.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            toast.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -20),
+            toast.heightAnchor.constraint(equalToConstant: 32),
+        ])
+
+        UIView.animate(withDuration: 0.3) { toast.alpha = 1.0 }
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) { [weak toast] in
+            UIView.animate(withDuration: 0.3, animations: {
+                toast?.alpha = 0
+            }, completion: { _ in toast?.removeFromSuperview() })
+        }
+    }
+
+    // MARK: - CLXAdRevenueDelegate
+
+    func didPayRevenue(for ad: CLXAd) {
+        DemoAppLogger.sharedInstance.logAdEvent("💰 Reels didPayRevenueForAd", ad: ad)
+    }
+
+    // MARK: - UICollectionViewDataSource
+
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        kReelsAdCount
+    }
+
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "ReelsCell", for: indexPath) as! ReelsCell
+        let item = items[indexPath.item]
+        cell.configure(with: item, at: indexPath.item)
+
+        if item.isLoaded, !item.isImagePlaceholder, let ad = item.ad {
+            item.loader?.renderNativeAdView(cell.nativeAdView, with: ad)
+        }
+
+        return cell
+    }
+
+    // MARK: - UICollectionViewDelegateFlowLayout
+
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+        collectionView.bounds.size
+    }
+}


### PR DESCRIPTION
## Summary
- Add NativeMenuViewController, NativeViewController, NativeFeedViewController, and ReelsFeedViewController to both ObjC and Swift demo apps (12 new files)
- Wire "Native" tab into AdDemoTabViewController for both demos
- Update Swift CLXDemoConfigManager with real native ad unit IDs (were placeholder `"-"`)

These screens were removed in PRs #271 and #281 when native ads were hidden from the public API.

## Related PRs
- **cloudx-ios-private**: cloudx-io/cloudx-ios-private#557 — un-hides native ad headers in SDK
- **JimsGame** (Blocky): cloudx-io/JimsGame#67 — re-enables iOS Reels feed

## Test plan
- [ ] ObjC demo app builds and shows Native tab with Single Ad / Feed / Reels sub-screens
- [ ] Swift demo app builds and shows Native tab with Single Ad / Feed / Reels sub-screens
- [ ] Native ads load in demo apps after xcframework is updated with public native headers

**Note**: Demo apps will not compile until the xcframework is rebuilt from cloudx-ios-private#557 with native headers included.

Made with [Cursor](https://cursor.com)