### PR TITLE
CXD-1061: align public iOS Swift demo QA config

### DIFF
--- a/demo-app-swift/CloudXSwiftRemotePods.xcodeproj/project.pbxproj
+++ b/demo-app-swift/CloudXSwiftRemotePods.xcodeproj/project.pbxproj
@@ -498,7 +498,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = cloudx.CloudXSwiftRemotePods;
+				PRODUCT_BUNDLE_IDENTIFIER = cloudx.CloudXObjCRemotePods;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "CloudXSwiftRemotePods/CloudXSwiftRemotePods-Bridging-Header.h";
@@ -529,7 +529,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = cloudx.CloudXSwiftRemotePods;
+				PRODUCT_BUNDLE_IDENTIFIER = cloudx.CloudXObjCRemotePods;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "CloudXSwiftRemotePods/CloudXSwiftRemotePods-Bridging-Header.h";

--- a/demo-app-swift/CloudXSwiftRemotePods/Configuration/CLXDemoConfigManager.swift
+++ b/demo-app-swift/CloudXSwiftRemotePods/Configuration/CLXDemoConfigManager.swift
@@ -40,17 +40,17 @@ class CLXDemoConfigManager {
     let currentConfig: CLXDemoConfig
     
     private init() {
-        // Production Configuration (SwiftDemoApp - bundle: cloudx.CloudXSwiftRemotePods)
+        // Production Configuration (ObjCDemoApp - bundle: cloudx.CloudXObjCRemotePods)
         self.currentConfig = CLXDemoConfig(
-            appKey: "xcQftcBSUmqzuv1LfET2o",
+            appKey: "ihtOXvp3X9JlMQ5p0_RYL",
             hashedUserId: "test-user-123",
-            bannerAdUnitId: "Ce5-ltAX5zFz5QJ3TzEjY",
-            mrecAdUnitId: "xMLHNFIkwieu2SLyeD0sQ",
-            interstitialAdUnitId: "rkw0ncj6mSphKtmnl8Cw_",
-            nativeAdUnitId: "-",
-            nativeBannerAdUnitId: "-",
-            rewardedAdUnitId: "WJje0XGqL5n56Sa8dlt8L",
-            rewardedInterstitialAdUnitId: "-"
+            bannerAdUnitId: "LyPxKhBFiUCd1xMLYQhGc",
+            mrecAdUnitId: "EWaeXDSmKYbs220gM5hTv",
+            interstitialAdUnitId: "txZ7NmISq-MsuPH0ULKbD",
+            nativeAdUnitId: "Q33RbPmBH-wix45Mu6--Z",
+            nativeBannerAdUnitId: "-2_Lw2b4QTlu7x6tKZ6Ww",
+            rewardedAdUnitId: "um9Ek08ScJBWuzSMTyW3b",
+            rewardedInterstitialAdUnitId: "I-JRnXEQc2bG5dm1EWoZ6"
         )
     }
 }


### PR DESCRIPTION
## Summary
- Align the public Swift demo bundle ID with the ObjC demo bundle ID for shared-dashboard QA runs.
- Replace the Swift demo production app key and ad unit IDs with the ObjC demo values so both demo apps exercise the same dashboard configuration.

## Test plan
- Not run separately in this public repo; equivalent private Swift demo build and Swift-only QA sweep were used to validate the shared-bundle harness path.

Linear: https://linear.app/cloudexchange/issue/CXD-1061

Made with [Cursor](https://cursor.com)