### PR TITLE
feat(demo-ios): inject app key / ad unit id at launch for QA (objc + swift)

### DIFF
--- a/demo-app-objc/CloudXObjCRemotePods/Configuration/CLXDemoConfigManager.m
+++ b/demo-app-objc/CloudXObjCRemotePods/Configuration/CLXDemoConfigManager.m
@@ -43,16 +43,32 @@
 - (instancetype)init {
     self = [super init];
     if (self) {
+        // QA can pin a specific app key / ad unit id at launch via
+        // `simctl launch ... -DemoApp.<Key> <value>` (NSArgumentDomain). Unset ->
+        // the hardcoded defaults below. Read once here (launch args are fixed for
+        // the process lifetime); nothing is written, so overrides never persist.
+        NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+        NSString *(^overrideOrDefault)(NSString *, NSString *) = ^NSString *(NSString *key, NSString *fallback) {
+            NSString *value = [defaults stringForKey:key];
+            return (value.length > 0) ? value : fallback;
+        };
+        NSLog(@"📱 [DemoApp] launch overrides: appKey=%@ banner=%@ mrec=%@ interstitial=%@ rewarded=%@",
+              [defaults stringForKey:@"DemoApp.AppKey"] ?: @"(none)",
+              [defaults stringForKey:@"DemoApp.BannerAdUnitId"] ?: @"(none)",
+              [defaults stringForKey:@"DemoApp.MrecAdUnitId"] ?: @"(none)",
+              [defaults stringForKey:@"DemoApp.InterstitialAdUnitId"] ?: @"(none)",
+              [defaults stringForKey:@"DemoApp.RewardedAdUnitId"] ?: @"(none)");
+
         // Production Configuration (ObjCDemoApp - bundle: cloudx.CloudXObjCRemotePods)
         _currentConfig = [[CLXDemoConfig alloc]
-            initWithAppKey:@"ihtOXvp3X9JlMQ5p0_RYL"
+            initWithAppKey:overrideOrDefault(@"DemoApp.AppKey", @"ihtOXvp3X9JlMQ5p0_RYL")
             hashedUserId:@"test-user-123"
-            bannerAdUnitId:@"LyPxKhBFiUCd1xMLYQhGc"
-            mrecAdUnitId:@"EWaeXDSmKYbs220gM5hTv"
-            interstitialAdUnitId:@"txZ7NmISq-MsuPH0ULKbD"
+            bannerAdUnitId:overrideOrDefault(@"DemoApp.BannerAdUnitId", @"LyPxKhBFiUCd1xMLYQhGc")
+            mrecAdUnitId:overrideOrDefault(@"DemoApp.MrecAdUnitId", @"EWaeXDSmKYbs220gM5hTv")
+            interstitialAdUnitId:overrideOrDefault(@"DemoApp.InterstitialAdUnitId", @"txZ7NmISq-MsuPH0ULKbD")
             nativeAdUnitId:@"Q33RbPmBH-wix45Mu6--Z"
             nativeBannerAdUnitId:@"-2_Lw2b4QTlu7x6tKZ6Ww"
-            rewardedAdUnitId:@"um9Ek08ScJBWuzSMTyW3b"
+            rewardedAdUnitId:overrideOrDefault(@"DemoApp.RewardedAdUnitId", @"um9Ek08ScJBWuzSMTyW3b")
             rewardedInterstitialAdUnitId:@"I-JRnXEQc2bG5dm1EWoZ6"];
     }
     return self;

--- a/demo-app-swift/CloudXSwiftRemotePods/Configuration/CLXDemoConfigManager.swift
+++ b/demo-app-swift/CloudXSwiftRemotePods/Configuration/CLXDemoConfigManager.swift
@@ -40,19 +40,30 @@ class CLXDemoConfigManager {
     let currentConfig: CLXDemoConfig
     
     private init() {
+        // QA can pin a specific app key / ad unit id at launch via
+        // `simctl launch ... -DemoApp.<Key> <value>` (NSArgumentDomain). Unset ->
+        // the hardcoded defaults. Read once; nothing is written, so overrides
+        // never persist across launches.
+        let defaults = UserDefaults.standard
+        func overrideOrDefault(_ key: String, _ fallback: String) -> String {
+            let value = defaults.string(forKey: key) ?? ""
+            return value.isEmpty ? fallback : value
+        }
+        NSLog("%@", "📱 [DemoApp] launch overrides: appKey=\(defaults.string(forKey: "DemoApp.AppKey") ?? "(none)") banner=\(defaults.string(forKey: "DemoApp.BannerAdUnitId") ?? "(none)") mrec=\(defaults.string(forKey: "DemoApp.MrecAdUnitId") ?? "(none)") interstitial=\(defaults.string(forKey: "DemoApp.InterstitialAdUnitId") ?? "(none)") rewarded=\(defaults.string(forKey: "DemoApp.RewardedAdUnitId") ?? "(none)")")
+
         // Production Configuration (shared with ObjC demo - bundle: cloudx.CloudXObjCRemotePods)
         // Both demos share the same SSP-side appKey, ad units, and bundle ID — they're the
         // same logical app, two language implementations. Only one can be installed per
         // simulator at a time (uninstall the other before installing).
         self.currentConfig = CLXDemoConfig(
-            appKey: "ihtOXvp3X9JlMQ5p0_RYL",
+            appKey: overrideOrDefault("DemoApp.AppKey", "ihtOXvp3X9JlMQ5p0_RYL"),
             hashedUserId: "test-user-123",
-            bannerAdUnitId: "LyPxKhBFiUCd1xMLYQhGc",
-            mrecAdUnitId: "EWaeXDSmKYbs220gM5hTv",
-            interstitialAdUnitId: "txZ7NmISq-MsuPH0ULKbD",
+            bannerAdUnitId: overrideOrDefault("DemoApp.BannerAdUnitId", "LyPxKhBFiUCd1xMLYQhGc"),
+            mrecAdUnitId: overrideOrDefault("DemoApp.MrecAdUnitId", "EWaeXDSmKYbs220gM5hTv"),
+            interstitialAdUnitId: overrideOrDefault("DemoApp.InterstitialAdUnitId", "txZ7NmISq-MsuPH0ULKbD"),
             nativeAdUnitId: "Q33RbPmBH-wix45Mu6--Z",
             nativeBannerAdUnitId: "-2_Lw2b4QTlu7x6tKZ6Ww",
-            rewardedAdUnitId: "um9Ek08ScJBWuzSMTyW3b",
+            rewardedAdUnitId: overrideOrDefault("DemoApp.RewardedAdUnitId", "um9Ek08ScJBWuzSMTyW3b"),
             rewardedInterstitialAdUnitId: "I-JRnXEQc2bG5dm1EWoZ6"
         )
     }


### PR DESCRIPTION
## Summary
Demo-app-only change (no SDK impact) so the release QA harness can point the public ObjC + Swift demos at a specific, often freshly-provisioned, ad unit without rebuilding — matching the private demos (cloudx-ios-private #811).

- `CLXDemoConfigManager` (ObjC + Swift) applies `-DemoApp.*` launch-arg overrides (`AppKey`, `BannerAdUnitId`, `MrecAdUnitId`, `InterstitialAdUnitId`, `RewardedAdUnitId`) read from `NSUserDefaults`' `NSArgumentDomain`. Unset → the hardcoded production defaults, so normal behavior is unchanged.
- These come only from the **volatile** argument domain and nothing writes them, so an injected id **never persists** to a later launch.

## Test plan
- [ ] Launch with `-DemoApp.BannerAdUnitId <id>`; confirm the demo requests that unit (oslog `launch overrides: ... banner=<id>`).
- [ ] Relaunch with no args; confirm it reverts to the hardcoded default (no persistence).
- [ ] Default launch behaves exactly as before.

Made with [Cursor](https://cursor.com)