### PR TITLE
Remove rewarded interstitial config from public iOS demo apps

### DIFF
--- a/demo-app-objc/CloudXObjCRemotePods/Configuration/CLXDemoConfigManager.h
+++ b/demo-app-objc/CloudXObjCRemotePods/Configuration/CLXDemoConfigManager.h
@@ -12,7 +12,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, readonly) NSString *nativeAdUnitId;
 @property (nonatomic, copy, readonly) NSString *nativeBannerAdUnitId;
 @property (nonatomic, copy, readonly) NSString *rewardedAdUnitId;
-@property (nonatomic, copy, readonly) NSString *rewardedInterstitialAdUnitId;
 
 - (instancetype)initWithAppKey:(NSString *)appKey
                  hashedUserId:(NSString *)hashedUserId
@@ -21,8 +20,7 @@ NS_ASSUME_NONNULL_BEGIN
          interstitialAdUnitId:(NSString *)interstitialAdUnitId
                nativeAdUnitId:(NSString *)nativeAdUnitId
          nativeBannerAdUnitId:(NSString *)nativeBannerAdUnitId
-             rewardedAdUnitId:(NSString *)rewardedAdUnitId
-   rewardedInterstitialAdUnitId:(NSString *)rewardedInterstitialAdUnitId;
+             rewardedAdUnitId:(NSString *)rewardedAdUnitId;
 
 @end
 

--- a/demo-app-objc/CloudXObjCRemotePods/Configuration/CLXDemoConfigManager.m
+++ b/demo-app-objc/CloudXObjCRemotePods/Configuration/CLXDemoConfigManager.m
@@ -9,8 +9,7 @@
          interstitialAdUnitId:(NSString *)interstitialAdUnitId
                nativeAdUnitId:(NSString *)nativeAdUnitId
          nativeBannerAdUnitId:(NSString *)nativeBannerAdUnitId
-             rewardedAdUnitId:(NSString *)rewardedAdUnitId
-   rewardedInterstitialAdUnitId:(NSString *)rewardedInterstitialAdUnitId {
+             rewardedAdUnitId:(NSString *)rewardedAdUnitId {
     
     self = [super init];
     if (self) {
@@ -22,7 +21,6 @@
         _nativeAdUnitId = [nativeAdUnitId copy];
         _nativeBannerAdUnitId = [nativeBannerAdUnitId copy];
         _rewardedAdUnitId = [rewardedAdUnitId copy];
-        _rewardedInterstitialAdUnitId = [rewardedInterstitialAdUnitId copy];
     }
     return self;
 }
@@ -68,8 +66,7 @@
             interstitialAdUnitId:overrideOrDefault(@"DemoApp.InterstitialAdUnitId", @"txZ7NmISq-MsuPH0ULKbD")
             nativeAdUnitId:@"Q33RbPmBH-wix45Mu6--Z"
             nativeBannerAdUnitId:@"-2_Lw2b4QTlu7x6tKZ6Ww"
-            rewardedAdUnitId:overrideOrDefault(@"DemoApp.RewardedAdUnitId", @"um9Ek08ScJBWuzSMTyW3b")
-            rewardedInterstitialAdUnitId:@"I-JRnXEQc2bG5dm1EWoZ6"];
+            rewardedAdUnitId:overrideOrDefault(@"DemoApp.RewardedAdUnitId", @"um9Ek08ScJBWuzSMTyW3b")];
     }
     return self;
 }

--- a/demo-app-swift/CloudXSwiftRemotePods/Configuration/CLXDemoConfigManager.swift
+++ b/demo-app-swift/CloudXSwiftRemotePods/Configuration/CLXDemoConfigManager.swift
@@ -9,7 +9,6 @@ class CLXDemoConfig {
     let nativeAdUnitId: String
     let nativeBannerAdUnitId: String
     let rewardedAdUnitId: String
-    let rewardedInterstitialAdUnitId: String
     
     init(appKey: String,
          hashedUserId: String,
@@ -18,8 +17,7 @@ class CLXDemoConfig {
          interstitialAdUnitId: String,
          nativeAdUnitId: String,
          nativeBannerAdUnitId: String,
-         rewardedAdUnitId: String,
-         rewardedInterstitialAdUnitId: String) {
+         rewardedAdUnitId: String) {
         
         self.appKey = appKey
         self.hashedUserId = hashedUserId
@@ -29,7 +27,6 @@ class CLXDemoConfig {
         self.nativeAdUnitId = nativeAdUnitId
         self.nativeBannerAdUnitId = nativeBannerAdUnitId
         self.rewardedAdUnitId = rewardedAdUnitId
-        self.rewardedInterstitialAdUnitId = rewardedInterstitialAdUnitId
     }
 }
 
@@ -63,8 +60,7 @@ class CLXDemoConfigManager {
             interstitialAdUnitId: overrideOrDefault("DemoApp.InterstitialAdUnitId", "txZ7NmISq-MsuPH0ULKbD"),
             nativeAdUnitId: "Q33RbPmBH-wix45Mu6--Z",
             nativeBannerAdUnitId: "-2_Lw2b4QTlu7x6tKZ6Ww",
-            rewardedAdUnitId: overrideOrDefault("DemoApp.RewardedAdUnitId", "um9Ek08ScJBWuzSMTyW3b"),
-            rewardedInterstitialAdUnitId: "I-JRnXEQc2bG5dm1EWoZ6"
+            rewardedAdUnitId: overrideOrDefault("DemoApp.RewardedAdUnitId", "um9Ek08ScJBWuzSMTyW3b")
         )
     }
 }


### PR DESCRIPTION
## Summary
- Remove unused `rewardedInterstitialAdUnitId` from Swift and ObjC demo config managers

The public demo apps never had a rewarded interstitial screen; this removes the dead config property now that CloudX does not support the format.

## Test plan
- [ ] Build `demo-app-swift` and `demo-app-objc`
- [ ] Confirm `git grep rewardedInterstitial demo-app-*` returns nothing

Made with [Cursor](https://cursor.com)