### PR TITLE
CXD-2685: widen network-SDK pins to flexible ranges (5 public adapters)

### DIFF
--- a/adapter-googlewaterfall/CloudXGoogleWaterfallAdapter.podspec
+++ b/adapter-googlewaterfall/CloudXGoogleWaterfallAdapter.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.vendored_frameworks = 'adapter-googlewaterfall/CloudXGoogleWaterfallAdapter.xcframework'
 
   s.dependency 'CloudXCore', '3.4.5'
-  s.dependency 'Google-Mobile-Ads-SDK', '12.14.0'
+  s.dependency 'Google-Mobile-Ads-SDK', '>= 12.14.0', '< 13.0'
 
   s.frameworks = ['AVFoundation', 'AVKit', 'AdSupport', 'CoreGraphics', 'CoreLocation', 'CoreTelephony', 'Foundation', 'StoreKit', 'SystemConfiguration', 'UIKit', 'WebKit']
   s.weak_frameworks = ['GoogleMobileAds']

--- a/adapter-magnite/CloudXMagniteAdapter.podspec
+++ b/adapter-magnite/CloudXMagniteAdapter.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
 
   # Dependencies
   s.dependency 'CloudXCore', '3.4.5'
-  s.dependency 'MagniteSDK', '~> 1.0.0'
+  s.dependency 'MagniteSDK', '>= 1.0.0', '< 2.0'
 
   s.frameworks = ['AVFoundation', 'AdSupport', 'CoreGraphics', 'CoreMedia', 'CoreTelephony', 'Foundation', 'JavaScriptCore', 'QuartzCore', 'StoreKit', 'SystemConfiguration', 'UIKit', 'WebKit']
   s.weak_frameworks = ['AppTrackingTransparency']

--- a/adapter-moloco/CloudXMolocoAdapter.podspec
+++ b/adapter-moloco/CloudXMolocoAdapter.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.vendored_frameworks = 'adapter-moloco/CloudXMolocoAdapter.xcframework'
 
   s.dependency 'CloudXCore', '3.4.5'
-  s.dependency 'MolocoSDKiOS', '~> 4.6.0'
+  s.dependency 'MolocoSDKiOS', '>= 4.6.0', '< 5.0'
 
   s.frameworks = ['AVFoundation', 'AVKit', 'AdSupport', 'CoreGraphics', 'CoreLocation', 'CoreTelephony', 'Foundation', 'StoreKit', 'SystemConfiguration', 'UIKit', 'WebKit']
 

--- a/adapter-pangle/CloudXPangleAdapter.podspec
+++ b/adapter-pangle/CloudXPangleAdapter.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.vendored_frameworks = 'adapter-pangle/CloudXPangleAdapter.xcframework'
 
   s.dependency 'CloudXCore', '3.4.5'
-  s.dependency 'Ads-Global', '~> 7.9.0'
+  s.dependency 'Ads-Global', '>= 7.9.0', '< 8.0'
 
   s.frameworks = ['AVFoundation', 'AdSupport', 'AudioToolbox', 'CFNetwork', 'CoreGraphics', 'CoreMedia', 'Foundation', 'StoreKit', 'SystemConfiguration', 'UIKit', 'WebKit']
 

--- a/adapter-verve/CloudXVerveAdapter.podspec
+++ b/adapter-verve/CloudXVerveAdapter.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.vendored_frameworks = 'adapter-verve/CloudXVerveAdapter.xcframework'
 
   s.dependency 'CloudXCore', '3.4.5'
-  s.dependency 'HyBid', '= 3.8.0'
+  s.dependency 'HyBid', '>= 3.8.0', '< 4.0'
 
   s.frameworks = ['AVFoundation', 'AdSupport', 'CoreFoundation', 'CoreAudio', 'CoreGraphics', 'CoreMedia', 'CoreTelephony', 'Foundation', 'JavaScriptCore', 'QuartzCore', 'StoreKit', 'SystemConfiguration', 'UIKit', 'WebKit']
   s.weak_frameworks = ['AppTrackingTransparency']


### PR DESCRIPTION
## Summary
Public binary-distribution mirror of **cloudx-io/cloudx-ios-private#924**. Converts tight network-SDK pins (patch `~>` / exact `=`) to flexible next-major ranges so publishers can resolve newer certified network-SDK minors without CocoaPods version conflicts.

Immediate driver is **CXD-2685**: the Moloco `~> 4.6.0` pin hard-excludes Moloco 4.8.0 (the release fixing the SwiftProtobuf transitive-dependency conflict), so publishers can't adopt it through the CloudX adapter.

## Changes

| Adapter | Pod | Before | After |
|---|---|---|---|
| moloco | MolocoSDKiOS | `~> 4.6.0` | `>= 4.6.0, < 5.0` |
| pangle | Ads-Global | `~> 7.9.0` | `>= 7.9.0, < 8.0` |
| magnite | MagniteSDK | `~> 1.0.0` | `>= 1.0.0, < 2.0` |
| verve | HyBid | `= 3.8.0` | `>= 3.8.0, < 4.0` |
| googlewaterfall | Google-Mobile-Ads-SDK | `12.14.0` | `>= 12.14.0, < 13.0` |

Floors stay at the certified versions; ceilings cap below the next major (where breaking changes land — Google v13 also raises the minimum Xcode). `CloudXCore` exact pins are left untouched.

## Notes
- **taurusx** is not published in this repo yet, so it is not part of this PR (it's covered in the private PR for when it ships publicly).
- **magnite** is the lowest-confidence widening (new SDK, no minor-release track record); a reviewer may prefer keeping `~> 1.0.0`.
- For the Moloco fix to actually ship to publishers, this needs to land **and** a new adapter release cut; re-cert QA against Moloco 4.8.0 still recommended.

## Test plan
- [ ] `pod install` against each adapter resolves the newest in-range network SDK.
- [ ] Demo apps load + render across formats per adapter.

Linear: https://linear.app/cloudx/issue/CXD-2685/update-moloco-adapter-for-v480-on-ios
Source PR: https://github.com/cloudx-io/cloudx-ios-private/pull/924

Made with [Cursor](https://cursor.com)