### PR TITLE
Point ObjC/Swift demo apps at gw-admob perma ad units

### DIFF
--- a/demo-app-objc/CloudXObjCRemotePods/Configuration/CLXDemoConfigManager.m
+++ b/demo-app-objc/CloudXObjCRemotePods/Configuration/CLXDemoConfigManager.m
@@ -61,12 +61,12 @@
         _currentConfig = [[CLXDemoConfig alloc]
             initWithAppKey:overrideOrDefault(@"DemoApp.AppKey", @"ihtOXvp3X9JlMQ5p0_RYL")
             hashedUserId:@"test-user-123"
-            bannerAdUnitId:overrideOrDefault(@"DemoApp.BannerAdUnitId", @"LyPxKhBFiUCd1xMLYQhGc")
-            mrecAdUnitId:overrideOrDefault(@"DemoApp.MrecAdUnitId", @"EWaeXDSmKYbs220gM5hTv")
-            interstitialAdUnitId:overrideOrDefault(@"DemoApp.InterstitialAdUnitId", @"txZ7NmISq-MsuPH0ULKbD")
-            nativeAdUnitId:@"Q33RbPmBH-wix45Mu6--Z"
+            bannerAdUnitId:overrideOrDefault(@"DemoApp.BannerAdUnitId", @"1pfZEjeYFB31WGsaRMIOE")
+            mrecAdUnitId:overrideOrDefault(@"DemoApp.MrecAdUnitId", @"f3vNAyybeLZw3tmrLDnfp")
+            interstitialAdUnitId:overrideOrDefault(@"DemoApp.InterstitialAdUnitId", @"SKva576GixtRW5DL_jS_D")
+            nativeAdUnitId:@"5NN7ZlBorm4ZoRkL6bsz9"
             nativeBannerAdUnitId:@"-2_Lw2b4QTlu7x6tKZ6Ww"
-            rewardedAdUnitId:overrideOrDefault(@"DemoApp.RewardedAdUnitId", @"um9Ek08ScJBWuzSMTyW3b")];
+            rewardedAdUnitId:overrideOrDefault(@"DemoApp.RewardedAdUnitId", @"jKOcqM-eHbGBwg76RQmsA")];
     }
     return self;
 }

--- a/demo-app-swift/CloudXSwiftRemotePods/Configuration/CLXDemoConfigManager.swift
+++ b/demo-app-swift/CloudXSwiftRemotePods/Configuration/CLXDemoConfigManager.swift
@@ -55,12 +55,12 @@ class CLXDemoConfigManager {
         self.currentConfig = CLXDemoConfig(
             appKey: overrideOrDefault("DemoApp.AppKey", "ihtOXvp3X9JlMQ5p0_RYL"),
             hashedUserId: "test-user-123",
-            bannerAdUnitId: overrideOrDefault("DemoApp.BannerAdUnitId", "LyPxKhBFiUCd1xMLYQhGc"),
-            mrecAdUnitId: overrideOrDefault("DemoApp.MrecAdUnitId", "EWaeXDSmKYbs220gM5hTv"),
-            interstitialAdUnitId: overrideOrDefault("DemoApp.InterstitialAdUnitId", "txZ7NmISq-MsuPH0ULKbD"),
-            nativeAdUnitId: "Q33RbPmBH-wix45Mu6--Z",
+            bannerAdUnitId: overrideOrDefault("DemoApp.BannerAdUnitId", "1pfZEjeYFB31WGsaRMIOE"),
+            mrecAdUnitId: overrideOrDefault("DemoApp.MrecAdUnitId", "f3vNAyybeLZw3tmrLDnfp"),
+            interstitialAdUnitId: overrideOrDefault("DemoApp.InterstitialAdUnitId", "SKva576GixtRW5DL_jS_D"),
+            nativeAdUnitId: "5NN7ZlBorm4ZoRkL6bsz9",
             nativeBannerAdUnitId: "-2_Lw2b4QTlu7x6tKZ6Ww",
-            rewardedAdUnitId: overrideOrDefault("DemoApp.RewardedAdUnitId", "um9Ek08ScJBWuzSMTyW3b")
+            rewardedAdUnitId: overrideOrDefault("DemoApp.RewardedAdUnitId", "jKOcqM-eHbGBwg76RQmsA")
         )
     }
 }


### PR DESCRIPTION
## Summary
- Updates the production banner/mrec/interstitial/native/rewarded ad unit IDs (ObjC + Swift demo config managers) to the seeded gw-admob perma ad units.
- App-open is not present in this public demo app config.

## Test plan
- Verified via the equivalent `cloudx-ios-private` demo app (same dashboard app, same ad units, published pods) — banner, interstitial, and native fully render a live AdMob test ad; rewarded reaches "Ad Ready".
- MREC intentionally excluded — it resolves to no-fill on the shared AdMob banner unit.

Made with [Cursor](https://cursor.com)