### PR TITLE
Prepare demo apps for 3.5.0 independent-versioning release

### DIFF
--- a/demo-app-objc/Podfile
+++ b/demo-app-objc/Podfile
@@ -3,19 +3,18 @@ platform :ios, '13.0'
 target 'CloudXObjCRemotePods' do
   use_frameworks! :linkage => :static
 
-  pod 'CloudXCore', '~> 3.4.6'
-  pod 'CloudXRenderer', '~> 3.4.6'
-  pod 'CloudXMetaAdapter', '~> 3.4.6'
-  pod 'CloudXVungleAdapter', '~> 3.4.6'
-  pod 'CloudXInMobiAdapter', '~> 3.4.6'
-  pod 'CloudXMintegralAdapter', '~> 3.4.6'
-  pod 'CloudXUnityAdsAdapter', '~> 3.4.6'
-  pod 'CloudXMagniteAdapter', '~> 3.4.6'
-  pod 'CloudXMolocoAdapter', '~> 3.4.6'
-  pod 'CloudXVerveAdapter', '~> 3.4.6'
-  pod 'CloudXDigitalTurbineAdapter', '~> 3.4.6'
-  pod 'CloudXGoogleWaterfallAdapter', '~> 3.4.6'
-  pod 'CloudXPangleAdapter', '~> 3.4.6'
+  pod 'CloudXCore', '~> 3.5.0'
+  pod 'CloudXMetaAdapter', '~> 6.21.1.0'
+  pod 'CloudXVungleAdapter', '~> 7.7.4.0'
+  pod 'CloudXInMobiAdapter', '~> 11.3.0.0'
+  pod 'CloudXMintegralAdapter', '~> 8.1.5.0'
+  pod 'CloudXUnityAdsAdapter', '~> 4.19.0.0'
+  pod 'CloudXMagniteAdapterV2', '~> 1.0.0.0'
+  pod 'CloudXMolocoAdapter', '~> 4.8.0.0'
+  pod 'CloudXVerveAdapter', '~> 3.9.0.0'
+  pod 'CloudXDigitalTurbineAdapter', '~> 8.4.8.0'
+  pod 'CloudXGoogleWaterfallAdapter', '~> 13.6.0.0'
+  pod 'CloudXPangleAdapter', '~> 7.9.1.3.0'
 
   target 'CloudXObjCRemotePodsTests' do
     inherit! :search_paths

--- a/demo-app-swift/Podfile
+++ b/demo-app-swift/Podfile
@@ -3,19 +3,18 @@ platform :ios, '13.0'
 target 'CloudXSwiftRemotePods' do
   use_frameworks! :linkage => :static
 
-  pod 'CloudXCore', '~> 3.4.6'
-  pod 'CloudXRenderer', '~> 3.4.6'
-  pod 'CloudXMetaAdapter', '~> 3.4.6'
-  pod 'CloudXVungleAdapter', '~> 3.4.6'
-  pod 'CloudXInMobiAdapter', '~> 3.4.6'
-  pod 'CloudXMintegralAdapter', '~> 3.4.6'
-  pod 'CloudXUnityAdsAdapter', '~> 3.4.6'
-  pod 'CloudXMagniteAdapter', '~> 3.4.6'
-  pod 'CloudXMolocoAdapter', '~> 3.4.6'
-  pod 'CloudXVerveAdapter', '~> 3.4.6'
-  pod 'CloudXDigitalTurbineAdapter', '~> 3.4.6'
-  pod 'CloudXGoogleWaterfallAdapter', '~> 3.4.6'
-  pod 'CloudXPangleAdapter', '~> 3.4.6'
+  pod 'CloudXCore', '~> 3.5.0'
+  pod 'CloudXMetaAdapter', '~> 6.21.1.0'
+  pod 'CloudXVungleAdapter', '~> 7.7.4.0'
+  pod 'CloudXInMobiAdapter', '~> 11.3.0.0'
+  pod 'CloudXMintegralAdapter', '~> 8.1.5.0'
+  pod 'CloudXUnityAdsAdapter', '~> 4.19.0.0'
+  pod 'CloudXMagniteAdapterV2', '~> 1.0.0.0'
+  pod 'CloudXMolocoAdapter', '~> 4.8.0.0'
+  pod 'CloudXVerveAdapter', '~> 3.9.0.0'
+  pod 'CloudXDigitalTurbineAdapter', '~> 8.4.8.0'
+  pod 'CloudXGoogleWaterfallAdapter', '~> 13.6.0.0'
+  pod 'CloudXPangleAdapter', '~> 7.9.1.3.0'
 
   target 'CloudXSwiftRemotePodsTests' do
     inherit! :search_paths


### PR DESCRIPTION
## Summary
- Flips both demo apps from the unified `~> 3.4.6` line to independent per-component pins matching the 3.5.0 release (wave-2 latest where released, wave-1 otherwise — see commit message for the full pin list).
- Swaps `CloudXMagniteAdapter` -> `CloudXMagniteAdapterV2` (new independent-versioned pod; module/import name unchanged).
- Removes `CloudXRenderer` (functionality now integrated into `CloudXCore`).
- No `CloudXTestHarness` reference — this PR does not carry any QA-window automation pods.

## Sequencing
`pod install` will not resolve until the component PRs (#89–106) merge and publish to CocoaPods trunk. This PR stages the Podfile changes ahead of that per the release runbook. **Do not merge until after trunk publish** — merging early would break `main`'s demo apps for anyone pulling in the meantime.

## Part of
iOS 3.5.0 release, final step before wave publish. See cloudx-ios-private `release/sdk_releases.md` §6 (post-release smoke test) for what runs after this merges.

Made with [Cursor](https://cursor.com)