### PR TITLE
docs(changelog): omit App Open from 3.5.0 pending fast-follow QA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,6 @@ Adapters now version independently of `CloudXCore`. Each adapter pod uses `<netw
 - **`CloudXRenderer` is no longer a separate pod.** Its functionality is built into `CloudXCore`; remove any direct `CloudXRenderer` dependency from your Podfile.
 
 ### Added
-- **App Open ad format** — New `CLXAppOpen` ad class (with `CLXAppOpenDelegate`) for full-screen ads shown while your app is loading or returning to the foreground. Create with `createAppOpen(adUnitId:)` (`createAppOpenWithAdUnitId:` in Objective-C). Supported on the Google Waterfall, Mintegral, Pangle, and Vungle adapters.
 - **VAST video interstitials and rewarded on the CloudX renderer** — The CloudX renderer now serves VAST video interstitial and rewarded creatives, with Open Measurement (OMID) video measurement. Rollout is controlled server-side; no integration change is required.
 - **HTML rewarded on the CloudX renderer** — HTML rewarded creatives now render through the CloudX renderer, completing the fullscreen HTML support introduced for interstitials in 3.4.5. Server-side rollout; no integration change required.
 - **Native ads on Mintegral, Pangle, and Verve** — These adapters now serve Native creatives, both standalone (via `CLXNativeAdLoader`) and native-in-banner / native-in-MREC. Native is now available across Meta, Vungle, InMobi, Moloco, Digital Turbine, Mintegral, Pangle, and Verve.


### PR DESCRIPTION
## Summary
- Removes the **App Open ad format** bullet from the 3.5.0 `Added` section of the public `CHANGELOG.md`.
- App Open shipped in the 3.5.0 binary but was **not** covered by the release QA sweep (it's excluded from the automated QA pool). Per the public-changelog audience test, we don't advertise a feature to publishers until it's verified end-to-end.
- Re-add App Open in the fast-follow release notes once QA verifies it.
- Keeps `CHANGELOG.md` in sync with the docs-repo iOS changelog mirror (cloudx-io/docs#170, which drops the same bullet).

## Test plan
- [ ] Docs-only. Confirm the 3.5.0 `Added` section no longer lists App Open and still lists VAST video, HTML rewarded, Native expansion, etc.

Made with [Cursor](https://cursor.com)