### PR TITLE
Scope shipped-notify to the core SDK release only

### DIFF
--- a/.github/workflows/shipped-notify.yml
+++ b/.github/workflows/shipped-notify.yml
@@ -28,6 +28,15 @@ on:
 jobs:
   notify-shipped:
     runs-on: ubuntu-latest
+    # #shipped gets ONE message per release wave: the core SDK release, whose
+    # body lists every adapter shipped in the wave. Adapter releases (tag
+    # `adapter-<name>/<version>`) publish alongside it but must NOT each post to
+    # #shipped — that would spam the channel with one message per adapter.
+    # #sdk-releases (Slack GitHub-app subscription) still fires for every
+    # release; only this #shipped post is scoped to the core release.
+    # workflow_dispatch (manual wiring test) has an empty release tag, so the
+    # guard lets it through.
+    if: ${{ github.event.release.tag_name == '' || !startsWith(github.event.release.tag_name, 'adapter-') }}
     steps:
       - name: Post release notes to #shipped
         # Test-mode fallbacks live in the script (keyed on EVENT_NAME), not in


### PR DESCRIPTION
## Summary
- The `shipped-notify` workflow triggered on **every** published release, so a release wave (core + N adapters) would post **N+1** messages to `#shipped` (one per adapter) instead of the single curated core-release announcement that already lists all adapters.
- Adds a job guard that skips `adapter-<name>/<version>` release tags. Only the core SDK release (`sdk/*`, `v*`, or any non-`adapter-` tag) posts to `#shipped`.
- `#sdk-releases` (Slack GitHub-app subscription) is unaffected — it still fires per release.
- `workflow_dispatch` (manual wiring test) has no release tag, so it still runs.

## Context
During the iOS 3.5.0 release, `#shipped` was posted once (curated, whole-wave). The workflow is currently **disabled** to avoid it firing (unscoped) on the 12 wave releases. After this merges — and once `SLACK_SHIPPED_WEBHOOK_URL` is set — re-enable it:
```
gh workflow enable "Notify #shipped" --repo cloudx-io/cloudx-ios
```

## Test plan
- [ ] Merge, set `SLACK_SHIPPED_WEBHOOK_URL`, re-enable the workflow.
- [ ] `gh workflow run "Notify #shipped"` (workflow_dispatch) posts a `[TEST]` message to `#shipped`.
- [ ] Next core release posts once; adapter releases post nothing to `#shipped`.

Made with [Cursor](https://cursor.com)