### PR TITLE
CXD-2749: Document AppsFlyer ad-revenue integration in public changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-*No unreleased changes*
+### Added
+- **AppsFlyer ad-revenue integration** — New `CloudXAppsFlyerIntegration` pod automatically forwards impression-level ad revenue for every CloudX-won impression (Banner, MREC, Interstitial, Rewarded, Native, App Open) to AppsFlyer. Add `pod 'CloudXAppsFlyerIntegration'` to your Podfile; the module self-registers with `CloudXCore` at load — no publisher glue code — and stays inert if your app doesn't use AppsFlyer. Requires `AppsFlyerFramework >= 6.15.0`: the integrated `logAdRevenue` API was introduced in AppsFlyer SDK 6.15.0, and AppsFlyer 6.14.x and below use a separate legacy AdRevenue connector that this module does not consume. If an older AppsFlyer is linked at runtime, the module logs a skip and never crashes.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- **AppsFlyer ad-revenue integration** — New `CloudXAppsFlyerIntegration` pod automatically forwards impression-level ad revenue for every CloudX-won impression (Banner, MREC, Interstitial, Rewarded, Native, App Open) to AppsFlyer. Add `pod 'CloudXAppsFlyerIntegration'` to your Podfile; the module self-registers with `CloudXCore` at load — no publisher glue code — and stays inert if your app doesn't use AppsFlyer. Requires `AppsFlyerFramework >= 6.15.0`: the integrated `logAdRevenue` API was introduced in AppsFlyer SDK 6.15.0, and AppsFlyer 6.14.x and below use a separate legacy AdRevenue connector that this module does not consume. If an older AppsFlyer is linked at runtime, the module logs a skip and never crashes.
+- **Global ad-revenue delegate** — New `+[CloudXCore addAdRevenueDelegate:]` / `removeAdRevenueDelegate:` API registers a global `CLXAdRevenueDelegate` that fires for every CloudX-won impression across all ad objects and formats — the surface analytics and MMP SDKs attach to, with no per-ad wiring.
+- **AppsFlyer ad-revenue connector** — New `CloudXAppsFlyerConnector` pod automatically forwards impression-level ad revenue for every CloudX-won impression (Banner, MREC, Interstitial, Rewarded, Native, App Open) to AppsFlyer. Add `pod 'CloudXAppsFlyerConnector'` to your Podfile; the module self-registers onto the global ad-revenue delegate at load — no publisher glue code — and stays inert if your app doesn't use AppsFlyer. Requires `CloudXCore >= 3.6.0` and `AppsFlyerFramework >= 6.15.0`: the integrated `logAdRevenue` API was introduced in AppsFlyer SDK 6.15.0, and AppsFlyer 6.14.x and below use a separate legacy AdRevenue connector that this module does not consume. If an older AppsFlyer is linked at runtime, the module logs a skip and never crashes.
 
 ---
 


### PR DESCRIPTION
Adds the unreleased AppsFlyer ad-revenue integration entry to the public iOS changelog under `[Unreleased]`.

- New `CloudXAppsFlyerIntegration` pod; auto-registers with `CloudXCore` at load (no publisher glue).
- Forwards impression-level revenue for every CloudX-won impression (Banner, MREC, Interstitial, Rewarded, Native, App Open).
- **Minimum `AppsFlyerFramework >= 6.15.0`** — the integrated `logAdRevenue:additionalParameters:` API shipped in AppsFlyer SDK 6.15.0. AppsFlyer 6.14.x and below use a separate legacy AdRevenue connector (first published as `adrevenue:6.9.0`) that this module does **not** consume.
- Degrades gracefully: if an older AppsFlyer is linked at runtime (bypassing the podspec pin), the module logs a once-only skip and never crashes.

Mirrors the internal entry on cloudx-ios-private #945. A docs-repo mirror PR follows.

Linear: https://linear.cloudx.io/issue/CXD-2749

Made with [Cursor](https://cursor.com)