### PR TITLE
CXD-3040: Update demo apps for 3.6.0 release

### DIFF
--- a/demo-app-objc/Podfile
+++ b/demo-app-objc/Podfile
@@ -3,7 +3,7 @@ platform :ios, '13.0'
 target 'CloudXObjCRemotePods' do
   use_frameworks! :linkage => :static
 
-  pod 'CloudXCore', '~> 3.5.0'
+  pod 'CloudXCore', '~> 3.6.0'
   pod 'CloudXMetaAdapter', '~> 6.21.1.0'
   pod 'CloudXVungleAdapter', '~> 7.7.4.0'
   pod 'CloudXInMobiAdapter', '~> 11.3.0.0'

--- a/demo-app-objc/Podfile.lock
+++ b/demo-app-objc/Podfile.lock
@@ -6,7 +6,7 @@ PODS:
     - Ads-Global/TikTokBusinessSDK
   - Ads-Global/PangleSDK (7.9.1.3)
   - Ads-Global/TikTokBusinessSDK (7.9.1.3)
-  - CloudXCore (3.5.0)
+  - CloudXCore (3.6.0)
   - CloudXDigitalTurbineAdapter (8.4.8.0):
     - CloudXCore (>= 3.5.0)
     - Fyber_Marketplace_SDK (= 8.4.8)
@@ -125,7 +125,7 @@ PODS:
   - VungleAds (7.7.4)
 
 DEPENDENCIES:
-  - CloudXCore (~> 3.5.0)
+  - CloudXCore (~> 3.6.0)
   - CloudXDigitalTurbineAdapter (~> 8.4.8.0)
   - CloudXGoogleWaterfallAdapter (~> 13.6.0.0)
   - CloudXInMobiAdapter (~> 11.3.0.0)
@@ -172,7 +172,7 @@ SPEC REPOS:
 
 SPEC CHECKSUMS:
   Ads-Global: 5d66442ebf73301114809e28a4d8606e98bf40ab
-  CloudXCore: 376046793f06b4fa925b47ebe18d7e63931beaeb
+  CloudXCore: 3b01d9bb72b5a3e2bacfbc3507b0677ed392f4c6
   CloudXDigitalTurbineAdapter: 0c37b4f298913b3a5611ef1f6a65aa50bd4bb9a9
   CloudXGoogleWaterfallAdapter: e2326c444c3a1879b17b0d28f32ca0b453e172b9
   CloudXInMobiAdapter: e8ce09e5ebad78dc10ddf1ec1991af8896d6c72c
@@ -200,6 +200,6 @@ SPEC CHECKSUMS:
   UnityCoherenceLib: d9be08c5b9c2880cb220c7ecd643f97ebda422b7
   VungleAds: 77bad219e9e4b34bf43ab2518bf2fac72b86100b
 
-PODFILE CHECKSUM: a687f282f16697f163ed79a551e197fde2164386
+PODFILE CHECKSUM: f20907d633bb21e0c87f71299db7f82fee615b0c
 
 COCOAPODS: 1.16.2

--- a/demo-app-swift/Podfile
+++ b/demo-app-swift/Podfile
@@ -3,7 +3,7 @@ platform :ios, '13.0'
 target 'CloudXSwiftRemotePods' do
   use_frameworks! :linkage => :static
 
-  pod 'CloudXCore', '~> 3.5.0'
+  pod 'CloudXCore', '~> 3.6.0'
   pod 'CloudXMetaAdapter', '~> 6.21.1.0'
   pod 'CloudXVungleAdapter', '~> 7.7.4.0'
   pod 'CloudXInMobiAdapter', '~> 11.3.0.0'

--- a/demo-app-swift/Podfile.lock
+++ b/demo-app-swift/Podfile.lock
@@ -6,7 +6,7 @@ PODS:
     - Ads-Global/TikTokBusinessSDK
   - Ads-Global/PangleSDK (7.9.1.3)
   - Ads-Global/TikTokBusinessSDK (7.9.1.3)
-  - CloudXCore (3.5.0)
+  - CloudXCore (3.6.0)
   - CloudXDigitalTurbineAdapter (8.4.8.0):
     - CloudXCore (>= 3.5.0)
     - Fyber_Marketplace_SDK (= 8.4.8)
@@ -125,7 +125,7 @@ PODS:
   - VungleAds (7.7.4)
 
 DEPENDENCIES:
-  - CloudXCore (~> 3.5.0)
+  - CloudXCore (~> 3.6.0)
   - CloudXDigitalTurbineAdapter (~> 8.4.8.0)
   - CloudXGoogleWaterfallAdapter (~> 13.6.0.0)
   - CloudXInMobiAdapter (~> 11.3.0.0)
@@ -172,7 +172,7 @@ SPEC REPOS:
 
 SPEC CHECKSUMS:
   Ads-Global: 5d66442ebf73301114809e28a4d8606e98bf40ab
-  CloudXCore: 376046793f06b4fa925b47ebe18d7e63931beaeb
+  CloudXCore: 3b01d9bb72b5a3e2bacfbc3507b0677ed392f4c6
   CloudXDigitalTurbineAdapter: 0c37b4f298913b3a5611ef1f6a65aa50bd4bb9a9
   CloudXGoogleWaterfallAdapter: e2326c444c3a1879b17b0d28f32ca0b453e172b9
   CloudXInMobiAdapter: e8ce09e5ebad78dc10ddf1ec1991af8896d6c72c
@@ -200,6 +200,6 @@ SPEC CHECKSUMS:
   UnityCoherenceLib: d9be08c5b9c2880cb220c7ecd643f97ebda422b7
   VungleAds: 77bad219e9e4b34bf43ab2518bf2fac72b86100b
 
-PODFILE CHECKSUM: 42feebe8b073374f5e76ad1f3c2e5d21505228db
+PODFILE CHECKSUM: be8d7950b533288f16ef6d8d14efc9078585c41f
 
 COCOAPODS: 1.16.2


### PR DESCRIPTION
Points both demo apps at the published `CloudXCore 3.6.0` pod.

This is the standard post-publication step — the pin could not land in the release PR because `~> 3.6.0` does not resolve from the CDN until the pod is on trunk. `CloudXCore 3.6.0` published to trunk on 2026-07-29 and both lockfiles were regenerated against it.

## Verification

- `pod install` resolves `CloudXCore (3.6.0)` in both apps
- Neither lockfile contains an `EXTERNAL SOURCES` section, so both resolve purely from trunk with no local `:path` sources

Only the `CloudXCore` pin moves; adapter pins are unchanged.

Made with [Cursor](https://cursor.com)