### PR TITLE
qa: Add inline-abandon hook to demo apps for dealloc verification

### DIFF
--- a/demo-app-objc/CloudXObjCRemotePods/CLXDeepLinkRouter.m
+++ b/demo-app-objc/CloudXObjCRemotePods/CLXDeepLinkRouter.m
@@ -92,6 +92,15 @@ static NSDictionary<NSString *, NSString *> *classNameMap(void) {
     return nil;
 }
 
+#pragma mark - QA Negative Path
+
+// Nil for formats with no abandon hook — the engine reads nil as
+// "this mode is not supported for this format."
+- (nullable SEL)abandonSelectorForFormat:(NSString *)format {
+    if ([format isEqualToString:@"banner"])                return @selector(abandonBannerAd);
+    return nil;
+}
+
 #pragma mark - Ad State
 
 - (BOOL)hasReceivedCallback:(CLXTestCallback)event forVC:(UIViewController *)vc {

--- a/demo-app-objc/CloudXObjCRemotePods/Views/Ad/BannerViewController.m
+++ b/demo-app-objc/CloudXObjCRemotePods/Views/Ad/BannerViewController.m
@@ -296,6 +296,24 @@
     [self updateStatusUIWithState:AdStateNoAd];
 }
 
+#pragma mark - QA Negative Path
+
+/**
+ * @brief QA-only: abandons the banner WITHOUT calling -destroy.
+ * @discussion Reproduces the publisher mistake this scenario exists to catch.
+ * `removeFromSuperview` + nil drops every strong owner so the SDK's ad view
+ * deallocs; omitting -destroy is deliberate, since destroying would exercise
+ * the normal teardown path and prove nothing. Reachable only through the
+ * deep-link router — do NOT copy this as integration practice.
+ */
+- (void)abandonBannerAd {
+    [self.bannerAd removeFromSuperview];
+    self.bannerAd = nil;
+    self.isLoading = NO;
+    self.receivedCallbacks = AdCallbackEventNone;
+    [self updateStatusUIWithState:AdStateNoAd];
+}
+
 #pragma mark - CLXBannerDelegate
 - (void)didLoadAd:(CLXAd *)ad {
     [[DemoAppLogger sharedInstance] logAdEvent:@"✅ Banner didLoadAd" ad:ad];

--- a/demo-app-swift/CloudXSwiftRemotePods/DeepLinkRouter.swift
+++ b/demo-app-swift/CloudXSwiftRemotePods/DeepLinkRouter.swift
@@ -93,6 +93,17 @@ private final class Adapter: NSObject, CLXTestHarnessApp {
         }
     }
 
+    // MARK: - QA Negative Path
+
+    // Nil for formats with no abandon hook — the engine reads nil as
+    // "this mode is not supported for this format."
+    func abandonSelector(forFormat format: String) -> Selector? {
+        switch format {
+        case "banner":                return NSSelectorFromString("abandonBannerAd")
+        default:                      return nil
+        }
+    }
+
     // MARK: - Ad State
 
     func hasReceivedCallback(_ event: CLXTestCallback, forVC vc: UIViewController) -> Bool {

--- a/demo-app-swift/CloudXSwiftRemotePods/Views/Ad/BannerViewController.swift
+++ b/demo-app-swift/CloudXSwiftRemotePods/Views/Ad/BannerViewController.swift
@@ -217,6 +217,23 @@ class BannerViewController: BaseAdViewController {
         updateStatusUI(state: .noAd)
     }
 
+    // MARK: - QA Negative Path
+
+    /// QA-only: abandons the banner WITHOUT calling `destroy()`.
+    ///
+    /// Reproduces the publisher mistake this scenario exists to catch.
+    /// `removeFromSuperview` + nil drops every strong owner so the SDK's ad view
+    /// deallocs; omitting `destroy()` is deliberate, since destroying would
+    /// exercise the normal teardown path and prove nothing. Reachable only
+    /// through the deep-link router — do NOT copy this as integration practice.
+    @objc private func abandonBannerAd() {
+        bannerAd?.removeFromSuperview()
+        bannerAd = nil
+        isLoading = false
+        receivedCallbacks = []
+        updateStatusUI(state: .noAd)
+    }
+
     override func adViewForClickTesting() -> UIView? { bannerAd ?? deferredBannerAd }
 }
 


### PR DESCRIPTION
## Why

The QA sweep cannot exercise the inline-abandonment path, because these demo apps always call `destroy()` before releasing an ad view — `BannerViewController` destroys even on `viewWillDisappear`. That means the publisher mistake of dropping an ad view without destroying it is never tested, which is why that defect showed up in production telemetry rather than in QA.

This adds the hook the harness needs to drive that path.

## What

`abandonBannerAd` in both the ObjC and Swift demo apps: `removeFromSuperview` plus nilling the reference, deliberately **without** `destroy()`. That drops every strong owner (the superview and the view controller), so the SDK's ad view deallocs. Omitting `destroy()` is the entire point — destroying would exercise the normal teardown path and prove nothing.

Exposed only through the existing deep-link router via `abandonSelectorForFormat:`.

## Deliberately unchanged

- No new UI. The hook is not reachable by a user of the app.
- No `CloudXTestHarness` import added to demo sources, and no `Podfile` / `Podfile.lock` changes — the release checkpoint polices both.
- `viewWillDisappear` and `resetAdState` are untouched. Because `resetAdState` is guarded by `if (self.bannerAd)`, nilling the reference first makes the later teardown a no-op, so normal load and teardown behavior is byte-identical.

Both hooks carry a doc comment stating they model a publisher mistake for QA and must not be copied as integration practice.

## Verification

Both apps build. Only 4 source files change, 55 insertions, no deletions.

## Companion

Harness mode, contracts, and the FAIL-severity verifiers: cloudx-io/mobile#92

Made with [Cursor](https://cursor.com)