### PR TITLE
CXD-2605: Pin CloudXTaurusXAdapter in the public demo Podfiles

### DIFF
--- a/demo-app-objc/Podfile
+++ b/demo-app-objc/Podfile
@@ -16,9 +16,7 @@ target 'CloudXObjCRemotePods' do
   pod 'CloudXGoogleWaterfallAdapter', '~> 13.6.0.0'
   pod 'CloudXPangleAdapter', '~> 8.2.0.7.0'
   pod 'CloudXMobileFuseAdapter', '~> 1.11.0.0'
-  # TaurusX 1.18.1.0 released 2026-08-03 (demand outage resolved). Uncomment
-  # once the pod is visible on the CocoaPods CDN (post-publish flip PR).
-  # pod 'CloudXTaurusXAdapter', '~> 1.18.1.0'
+  pod 'CloudXTaurusXAdapter', '~> 1.18.1.0'
 
   target 'CloudXObjCRemotePodsTests' do
     inherit! :search_paths

--- a/demo-app-swift/Podfile
+++ b/demo-app-swift/Podfile
@@ -16,9 +16,7 @@ target 'CloudXSwiftRemotePods' do
   pod 'CloudXGoogleWaterfallAdapter', '~> 13.6.0.0'
   pod 'CloudXPangleAdapter', '~> 8.2.0.7.0'
   pod 'CloudXMobileFuseAdapter', '~> 1.11.0.0'
-  # TaurusX 1.18.1.0 released 2026-08-03 (demand outage resolved). Uncomment
-  # once the pod is visible on the CocoaPods CDN (post-publish flip PR).
-  # pod 'CloudXTaurusXAdapter', '~> 1.18.1.0'
+  pod 'CloudXTaurusXAdapter', '~> 1.18.1.0'
 
   target 'CloudXSwiftRemotePodsTests' do
     inherit! :search_paths


### PR DESCRIPTION
## Summary

Uncomments the `CloudXTaurusXAdapter` pin in both public demo Podfiles now that the pod is live.

The pin was deliberately held commented with a note to flip it "once the pod is visible on the CocoaPods CDN (post-publish flip PR)". That precondition is now met:

- `CloudXTaurusXAdapter 1.18.1.0` published to CocoaPods trunk
- Visible on the CDN shard index (`all_pods_versions_8_6_0.txt`)
- Consumer install + link verified: `pod install` resolves `1.18.1.0` (with `TaurusxAdsSDK 1.18.1`) and the ObjC demo builds with `-framework CloudXTaurusXAdapter`

Both Podfiles are flipped together, so ObjC/Swift demo adapter-set parity is preserved (14 CloudX pods each).

## Test plan

- [x] `pod install` against trunk resolves `CloudXTaurusXAdapter (1.18.1.0)`
- [x] ObjC demo workspace builds against a simulator with the trunk pod
- [ ] CI green

Made with [Cursor](https://cursor.com)