### PR TITLE
Point demo apps at CloudXCore 3.7.0

### DIFF
--- a/demo-app-objc/Podfile
+++ b/demo-app-objc/Podfile
@@ -3,7 +3,7 @@ platform :ios, '13.0'
 target 'CloudXObjCRemotePods' do
   use_frameworks! :linkage => :static
 
-  pod 'CloudXCore', '~> 3.6.0'
+  pod 'CloudXCore', '~> 3.7.0'
   pod 'CloudXMetaAdapter', '~> 6.21.1.0'
   pod 'CloudXVungleAdapter', '~> 7.7.4.0'
   pod 'CloudXInMobiAdapter', '~> 11.3.0.0'

--- a/demo-app-objc/Podfile.lock
+++ b/demo-app-objc/Podfile.lock
@@ -6,7 +6,7 @@ PODS:
     - Ads-Global/TikTokBusinessSDK
   - Ads-Global/PangleSDK (8.2.0.7)
   - Ads-Global/TikTokBusinessSDK (8.2.0.7)
-  - CloudXCore (3.6.0)
+  - CloudXCore (3.7.0)
   - CloudXDigitalTurbineAdapter (8.4.8.0):
     - CloudXCore (>= 3.5.0)
     - Fyber_Marketplace_SDK (= 8.4.8)
@@ -39,6 +39,9 @@ PODS:
   - CloudXPangleAdapter (8.2.0.7.0):
     - Ads-Global (= 8.2.0.7)
     - CloudXCore (>= 3.5.0)
+  - CloudXTaurusXAdapter (1.18.1.0):
+    - CloudXCore (>= 3.5.0)
+    - TaurusxAdsSDK (= 1.18.1)
   - CloudXUnityAdsAdapter (4.19.0.0):
     - CloudXCore (>= 3.5.0)
     - UnityAds (= 4.19.0)
@@ -118,6 +121,9 @@ PODS:
     - MintegralAdSDK/NativeAd
   - MobileFuseSDK (1.11.0)
   - MolocoSDKiOS (4.8.0)
+  - TaurusxAdsSDK (1.18.1):
+    - TaurusxAdsSDK/TaurusxAds (= 1.18.1)
+  - TaurusxAdsSDK/TaurusxAds (1.18.1)
   - UnityAds (4.19.0):
     - IronSourceAdQualitySDK (< 10.0.0)
     - UnityCoherenceLib (= 0.1.0)
@@ -125,7 +131,7 @@ PODS:
   - VungleAds (7.7.4)
 
 DEPENDENCIES:
-  - CloudXCore (~> 3.6.0)
+  - CloudXCore (~> 3.7.0)
   - CloudXDigitalTurbineAdapter (~> 8.4.8.0)
   - CloudXGoogleWaterfallAdapter (~> 13.6.0.0)
   - CloudXInMobiAdapter (~> 11.3.0.0)
@@ -135,6 +141,7 @@ DEPENDENCIES:
   - CloudXMobileFuseAdapter (~> 1.11.0.0)
   - CloudXMolocoAdapter (~> 4.8.0.0)
   - CloudXPangleAdapter (~> 8.2.0.7.0)
+  - CloudXTaurusXAdapter (~> 1.18.1.0)
   - CloudXUnityAdsAdapter (~> 4.19.0.0)
   - CloudXVerveAdapter (~> 3.9.0.0)
   - CloudXVungleAdapter (~> 7.7.4.0)
@@ -152,6 +159,7 @@ SPEC REPOS:
     - CloudXMobileFuseAdapter
     - CloudXMolocoAdapter
     - CloudXPangleAdapter
+    - CloudXTaurusXAdapter
     - CloudXUnityAdsAdapter
     - CloudXVerveAdapter
     - CloudXVungleAdapter
@@ -166,13 +174,14 @@ SPEC REPOS:
     - MintegralAdSDK
     - MobileFuseSDK
     - MolocoSDKiOS
+    - TaurusxAdsSDK
     - UnityAds
     - UnityCoherenceLib
     - VungleAds
 
 SPEC CHECKSUMS:
   Ads-Global: c4da8b23232e80b87ac55964da167ba589502f6b
-  CloudXCore: 3b01d9bb72b5a3e2bacfbc3507b0677ed392f4c6
+  CloudXCore: afb57eb624a12b4db7988eef214d1a470236b7bd
   CloudXDigitalTurbineAdapter: 0c37b4f298913b3a5611ef1f6a65aa50bd4bb9a9
   CloudXGoogleWaterfallAdapter: e2326c444c3a1879b17b0d28f32ca0b453e172b9
   CloudXInMobiAdapter: e8ce09e5ebad78dc10ddf1ec1991af8896d6c72c
@@ -182,6 +191,7 @@ SPEC CHECKSUMS:
   CloudXMobileFuseAdapter: ca409a65c5929dedfbda9ba6c0a235a8c691ad2f
   CloudXMolocoAdapter: 9fac672e3e527e5785c4c5f4c8023b2e4a04f655
   CloudXPangleAdapter: 38f85e9c8df8b1823f7a8e563c1a82cf90801f74
+  CloudXTaurusXAdapter: 109ce1a76500952bb4bf7cb30c320ffff6904e96
   CloudXUnityAdsAdapter: 1a74f0fb02a6faecce20e2b340818205aab23f17
   CloudXVerveAdapter: e2be0ed38595681731c6105a05dde34888447c93
   CloudXVungleAdapter: f9c41d7fc80bb576ec31e2466cb6e8c0183eb713
@@ -196,10 +206,11 @@ SPEC CHECKSUMS:
   MintegralAdSDK: 9e98161b5c5afdc7f5effe4f3969dd1cf0430ed1
   MobileFuseSDK: 08da0fcba90e7c208e2817f6964ff4f15bd6f285
   MolocoSDKiOS: 329ac6a702974f2fb9c6ffd4a71de879fc345ac9
+  TaurusxAdsSDK: 29e5c35767ed5e2fea98af096055a46851bbc4c0
   UnityAds: 40804188247edc15e4e173450a749dbb2fbc61c5
   UnityCoherenceLib: d9be08c5b9c2880cb220c7ecd643f97ebda422b7
   VungleAds: 77bad219e9e4b34bf43ab2518bf2fac72b86100b
 
-PODFILE CHECKSUM: 1897991d2817d30a5dc4cac29db5c7e8d3fc08f0
+PODFILE CHECKSUM: 6a4f6ef8ac8d0f46e64d42837dabd469f659892f
 
-COCOAPODS: 1.16.2
+COCOAPODS: 1.17.0

--- a/demo-app-swift/Podfile
+++ b/demo-app-swift/Podfile
@@ -3,7 +3,7 @@ platform :ios, '13.0'
 target 'CloudXSwiftRemotePods' do
   use_frameworks! :linkage => :static
 
-  pod 'CloudXCore', '~> 3.6.0'
+  pod 'CloudXCore', '~> 3.7.0'
   pod 'CloudXMetaAdapter', '~> 6.21.1.0'
   pod 'CloudXVungleAdapter', '~> 7.7.4.0'
   pod 'CloudXInMobiAdapter', '~> 11.3.0.0'

--- a/demo-app-swift/Podfile.lock
+++ b/demo-app-swift/Podfile.lock
@@ -6,7 +6,7 @@ PODS:
     - Ads-Global/TikTokBusinessSDK
   - Ads-Global/PangleSDK (8.2.0.7)
   - Ads-Global/TikTokBusinessSDK (8.2.0.7)
-  - CloudXCore (3.6.0)
+  - CloudXCore (3.7.0)
   - CloudXDigitalTurbineAdapter (8.4.8.0):
     - CloudXCore (>= 3.5.0)
     - Fyber_Marketplace_SDK (= 8.4.8)
@@ -39,6 +39,9 @@ PODS:
   - CloudXPangleAdapter (8.2.0.7.0):
     - Ads-Global (= 8.2.0.7)
     - CloudXCore (>= 3.5.0)
+  - CloudXTaurusXAdapter (1.18.1.0):
+    - CloudXCore (>= 3.5.0)
+    - TaurusxAdsSDK (= 1.18.1)
   - CloudXUnityAdsAdapter (4.19.0.0):
     - CloudXCore (>= 3.5.0)
     - UnityAds (= 4.19.0)
@@ -118,6 +121,9 @@ PODS:
     - MintegralAdSDK/NativeAd
   - MobileFuseSDK (1.11.0)
   - MolocoSDKiOS (4.8.0)
+  - TaurusxAdsSDK (1.18.1):
+    - TaurusxAdsSDK/TaurusxAds (= 1.18.1)
+  - TaurusxAdsSDK/TaurusxAds (1.18.1)
   - UnityAds (4.19.0):
     - IronSourceAdQualitySDK (< 10.0.0)
     - UnityCoherenceLib (= 0.1.0)
@@ -125,7 +131,7 @@ PODS:
   - VungleAds (7.7.4)
 
 DEPENDENCIES:
-  - CloudXCore (~> 3.6.0)
+  - CloudXCore (~> 3.7.0)
   - CloudXDigitalTurbineAdapter (~> 8.4.8.0)
   - CloudXGoogleWaterfallAdapter (~> 13.6.0.0)
   - CloudXInMobiAdapter (~> 11.3.0.0)
@@ -135,6 +141,7 @@ DEPENDENCIES:
   - CloudXMobileFuseAdapter (~> 1.11.0.0)
   - CloudXMolocoAdapter (~> 4.8.0.0)
   - CloudXPangleAdapter (~> 8.2.0.7.0)
+  - CloudXTaurusXAdapter (~> 1.18.1.0)
   - CloudXUnityAdsAdapter (~> 4.19.0.0)
   - CloudXVerveAdapter (~> 3.9.0.0)
   - CloudXVungleAdapter (~> 7.7.4.0)
@@ -152,6 +159,7 @@ SPEC REPOS:
     - CloudXMobileFuseAdapter
     - CloudXMolocoAdapter
     - CloudXPangleAdapter
+    - CloudXTaurusXAdapter
     - CloudXUnityAdsAdapter
     - CloudXVerveAdapter
     - CloudXVungleAdapter
@@ -166,13 +174,14 @@ SPEC REPOS:
     - MintegralAdSDK
     - MobileFuseSDK
     - MolocoSDKiOS
+    - TaurusxAdsSDK
     - UnityAds
     - UnityCoherenceLib
     - VungleAds
 
 SPEC CHECKSUMS:
   Ads-Global: c4da8b23232e80b87ac55964da167ba589502f6b
-  CloudXCore: 3b01d9bb72b5a3e2bacfbc3507b0677ed392f4c6
+  CloudXCore: afb57eb624a12b4db7988eef214d1a470236b7bd
   CloudXDigitalTurbineAdapter: 0c37b4f298913b3a5611ef1f6a65aa50bd4bb9a9
   CloudXGoogleWaterfallAdapter: e2326c444c3a1879b17b0d28f32ca0b453e172b9
   CloudXInMobiAdapter: e8ce09e5ebad78dc10ddf1ec1991af8896d6c72c
@@ -182,6 +191,7 @@ SPEC CHECKSUMS:
   CloudXMobileFuseAdapter: ca409a65c5929dedfbda9ba6c0a235a8c691ad2f
   CloudXMolocoAdapter: 9fac672e3e527e5785c4c5f4c8023b2e4a04f655
   CloudXPangleAdapter: 38f85e9c8df8b1823f7a8e563c1a82cf90801f74
+  CloudXTaurusXAdapter: 109ce1a76500952bb4bf7cb30c320ffff6904e96
   CloudXUnityAdsAdapter: 1a74f0fb02a6faecce20e2b340818205aab23f17
   CloudXVerveAdapter: e2be0ed38595681731c6105a05dde34888447c93
   CloudXVungleAdapter: f9c41d7fc80bb576ec31e2466cb6e8c0183eb713
@@ -196,10 +206,11 @@ SPEC CHECKSUMS:
   MintegralAdSDK: 9e98161b5c5afdc7f5effe4f3969dd1cf0430ed1
   MobileFuseSDK: 08da0fcba90e7c208e2817f6964ff4f15bd6f285
   MolocoSDKiOS: 329ac6a702974f2fb9c6ffd4a71de879fc345ac9
+  TaurusxAdsSDK: 29e5c35767ed5e2fea98af096055a46851bbc4c0
   UnityAds: 40804188247edc15e4e173450a749dbb2fbc61c5
   UnityCoherenceLib: d9be08c5b9c2880cb220c7ecd643f97ebda422b7
   VungleAds: 77bad219e9e4b34bf43ab2518bf2fac72b86100b
 
-PODFILE CHECKSUM: b636c5bea6258fcbefb36cd0fe39f98aa17005ea
+PODFILE CHECKSUM: 5ee4a48afda50c81562c594fa980bcbc5043d4c8
 
-COCOAPODS: 1.16.2
+COCOAPODS: 1.17.0


### PR DESCRIPTION
Bump both demo Podfiles to the published `CloudXCore ~> 3.7.0` and regenerate lockfiles from trunk (clean public install resolves 3.7.0, no `:path` sources).

🤖 Generated with [Claude Code](https://claude.com/claude-code)