### PR TITLE
Add Meta adapter 6.22.0.0 to the public changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## Meta adapter 6.22.0.0 - 2026-08-12
+
+Install: `pod 'CloudXMetaAdapter', '~> 6.22.0.0'`
+
+### Changed
+- **Requires iOS 15** — Certified with Meta Audience Network 6.22.0, which requires iOS 15.0. Apps that still support iOS 13 or 14 should stay on `CloudXMetaAdapter 6.21.1.0`, which keeps working with the current CloudX SDK and every other network.
+- **New Meta ad formats** — Audience Network 6.22 adds eCommerce and catalog formats, chained ads on iOS, and playable improvements. Meta serves these; no integration change is needed beyond updating the adapter.
+
+---
+
 ## Google Waterfall adapter 13.6.0.2 - 2026-08-11
 
 ### Added


### PR DESCRIPTION
Public changelog entry for `CloudXMetaAdapter 6.22.0.0`. Source change in cloudx-io/mobile#223; internal changelog in cloudx-io/mobile#233; docs in cloudx-io/docs#283.

Two bullets, 248 and 212 characters — both within the 300-char cap.

Leads with the iOS 15 requirement rather than the format list, because it is a **breaking** integration change: adding `pod 'CloudXMetaAdapter'` to an iOS 13 target is a hard resolution error (`Specs satisfying the CloudXMetaAdapter dependency were found, but they required a higher minimum deployment target`), so a publisher is stopped at `pod install`. Publishers on iOS 13/14 should stay on `6.21.1.0`.

_An earlier revision of this description said CocoaPods only warns and installs anyway. That is true only when the floor arrives via `FBAudienceNetwork` as a direct dependency — the adapter's own dev `Podfile` — not via our podspec, which is the path publishers take. Corrected in cloudx-io/mobile#250._

Branched from `main`, so it is independent of the unmerged `cxd-2749-appsflyer-changelog` work.

## ⚠️ The release is blocked by a pre-existing gate failure, not by this PR

`publish-adapter-release.sh` runs `verify-changelog-style.py` against the **entire** `CHANGELOG.md` with no version scoping, and fails closed. Three bullets exceed the 300-char cap — all in sections shipped in May:

| Line | Section | Length |
| --- | --- | --- |
| 71 | `[3.4.2] - 2026-05-29` | 500 |
| 92 | `[3.4.0] - 2026-05-22` | 526 |
| 97 | `[3.4.0] - 2026-05-22` | 335 |

None are touched by this PR, and this would block **any** iOS release equally — Meta is simply the first to hit it. Two ways out, and it is a maintainer call:

1. **Trim the three historical bullets** — quick, but rewrites release notes publishers have already read.
2. **Scope the gate to the version being released** — arguably the real fix, since the gate exists to stop *new* unreadable prose shipping and cannot retroactively improve the past. Own PR against the shared script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
