### PR TITLE
Demo apps: add the app-open route and tab to both public demos

### DIFF
--- a/demo-app-objc/CloudXObjCRemotePods.xcodeproj/project.pbxproj
+++ b/demo-app-objc/CloudXObjCRemotePods.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		4304660232FB6017F7F0D18A /* AppOpenViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = B2B71D2A655E7F1E380B7759 /* AppOpenViewController.m */; };
 		4D1BF4C5F92675642717F5C8 /* Pods_CloudXObjCRemotePods.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0EFCC9FCA13563A8D80AF7B8 /* Pods_CloudXObjCRemotePods.framework */; };
 		DB1A3479B80CC9ABA45AB57F /* Pods_CloudXObjCRemotePodsTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A0D4FCB786F453EE8973683F /* Pods_CloudXObjCRemotePodsTests.framework */; };
 		E74CDA6447A608850B5827D0 /* Pods_CloudXObjCRemotePods_CloudXObjCRemotePodsUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4C1495C456E32020A2DBFA7B /* Pods_CloudXObjCRemotePods_CloudXObjCRemotePodsUITests.framework */; };
@@ -41,6 +42,8 @@
 		A0D4FCB786F453EE8973683F /* Pods_CloudXObjCRemotePodsTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_CloudXObjCRemotePodsTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		A40458EC3AD631AE6B12F446 /* Pods-CloudXObjCRemotePods-CloudXObjCRemotePodsUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CloudXObjCRemotePods-CloudXObjCRemotePodsUITests.debug.xcconfig"; path = "Target Support Files/Pods-CloudXObjCRemotePods-CloudXObjCRemotePodsUITests/Pods-CloudXObjCRemotePods-CloudXObjCRemotePodsUITests.debug.xcconfig"; sourceTree = "<group>"; };
 		A6314066CA80434B916D0F56 /* Pods-CloudXObjCRemotePods.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CloudXObjCRemotePods.release.xcconfig"; path = "Target Support Files/Pods-CloudXObjCRemotePods/Pods-CloudXObjCRemotePods.release.xcconfig"; sourceTree = "<group>"; };
+		B2B71D2A655E7F1E380B7759 /* AppOpenViewController.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = AppOpenViewController.m; sourceTree = "<group>"; };
+		E5CB8B7D3B426782BBDBDCF5 /* AppOpenViewController.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = AppOpenViewController.h; sourceTree = "<group>"; };
 		F89B8145BA2DAF534CF75E9B /* Pods-CloudXObjCRemotePods.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CloudXObjCRemotePods.debug.xcconfig"; path = "Target Support Files/Pods-CloudXObjCRemotePods/Pods-CloudXObjCRemotePods.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -116,6 +119,7 @@
 				1967EE322DDFC83700D3E27F /* Products */,
 				1A95DEE5D516B0EB1661FFE3 /* Pods */,
 				93F63A86B0AD57454300B3CF /* Frameworks */,
+				EC720A67BD53014D4A7446A7 /* CloudXObjCRemotePods */,
 			);
 			sourceTree = "<group>";
 		};
@@ -142,6 +146,15 @@
 			path = Pods;
 			sourceTree = "<group>";
 		};
+		4FC3887524CAC5EA076E4382 /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				E0E93322D765256DE0AFCE0D /* Ad */,
+			);
+			name = Views;
+			path = Views;
+			sourceTree = "<group>";
+		};
 		93F63A86B0AD57454300B3CF /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
@@ -150,6 +163,25 @@
 				A0D4FCB786F453EE8973683F /* Pods_CloudXObjCRemotePodsTests.framework */,
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		E0E93322D765256DE0AFCE0D /* Ad */ = {
+			isa = PBXGroup;
+			children = (
+				E5CB8B7D3B426782BBDBDCF5 /* AppOpenViewController.h */,
+				B2B71D2A655E7F1E380B7759 /* AppOpenViewController.m */,
+			);
+			name = Ad;
+			path = Ad;
+			sourceTree = "<group>";
+		};
+		EC720A67BD53014D4A7446A7 /* CloudXObjCRemotePods */ = {
+			isa = PBXGroup;
+			children = (
+				4FC3887524CAC5EA076E4382 /* Views */,
+			);
+			name = CloudXObjCRemotePods;
+			path = CloudXObjCRemotePods;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -433,6 +465,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4304660232FB6017F7F0D18A /* AppOpenViewController.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/demo-app-objc/CloudXObjCRemotePods/CLXDeepLinkRouter.m
+++ b/demo-app-objc/CloudXObjCRemotePods/CLXDeepLinkRouter.m
@@ -20,6 +20,8 @@ static NSDictionary<NSString *, NSString *> *classNameMap(void) {
             @"mrec":                   @"MRECViewController",
             @"interstitial":           @"InterstitialViewController",
             @"rewarded":               @"RewardedViewController",
+
+            @"app-open":               @"AppOpenViewController",
             @"native":                 @"NativeMenuViewController",
         };
     });
@@ -69,11 +71,12 @@ static NSDictionary<NSString *, NSString *> *classNameMap(void) {
 #pragma mark - Format Configuration
 
 - (NSArray<NSString *> *)supportedFormats {
-    return @[@"banner", @"mrec", @"interstitial", @"rewarded", @"native"];
+    return @[@"banner", @"mrec", @"interstitial", @"app-open", @"rewarded", @"native"];
 }
 
 - (BOOL)isFullscreenFormat:(NSString *)format {
     return [format isEqualToString:@"interstitial"] ||
+           [format isEqualToString:@"app-open"] ||
            [format isEqualToString:@"rewarded"];
 }
 
@@ -82,6 +85,8 @@ static NSDictionary<NSString *, NSString *> *classNameMap(void) {
     if ([format isEqualToString:@"mrec"])                  return @selector(loadMRECAd);
     if ([format isEqualToString:@"interstitial"])           return @selector(loadInterstitialAd);
     if ([format isEqualToString:@"rewarded"])               return @selector(loadRewardedAd);
+
+    if ([format isEqualToString:@"app-open"])               return @selector(loadAppOpenAd);
     if ([format isEqualToString:@"native"])                 return @selector(loadNativeAd);
     return nil;
 }
@@ -89,6 +94,8 @@ static NSDictionary<NSString *, NSString *> *classNameMap(void) {
 - (nullable SEL)showSelectorForFormat:(NSString *)format {
     if ([format isEqualToString:@"interstitial"])           return @selector(showInterstitialAd);
     if ([format isEqualToString:@"rewarded"])               return @selector(showRewardedAd);
+
+    if ([format isEqualToString:@"app-open"])               return @selector(showAppOpenAd);
     return nil;
 }
 

--- a/demo-app-objc/CloudXObjCRemotePods/Configuration/CLXDemoConfigManager.h
+++ b/demo-app-objc/CloudXObjCRemotePods/Configuration/CLXDemoConfigManager.h
@@ -12,6 +12,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, readonly) NSString *nativeAdUnitId;
 @property (nonatomic, copy, readonly) NSString *nativeBannerAdUnitId;
 @property (nonatomic, copy, readonly) NSString *rewardedAdUnitId;
+@property (nonatomic, copy, readonly) NSString *appOpenAdUnitId;
 
 - (instancetype)initWithAppKey:(NSString *)appKey
                  hashedUserId:(NSString *)hashedUserId
@@ -20,7 +21,8 @@ NS_ASSUME_NONNULL_BEGIN
          interstitialAdUnitId:(NSString *)interstitialAdUnitId
                nativeAdUnitId:(NSString *)nativeAdUnitId
          nativeBannerAdUnitId:(NSString *)nativeBannerAdUnitId
-             rewardedAdUnitId:(NSString *)rewardedAdUnitId;
+             rewardedAdUnitId:(NSString *)rewardedAdUnitId
+              appOpenAdUnitId:(NSString *)appOpenAdUnitId;
 
 @end
 

--- a/demo-app-objc/CloudXObjCRemotePods/Configuration/CLXDemoConfigManager.m
+++ b/demo-app-objc/CloudXObjCRemotePods/Configuration/CLXDemoConfigManager.m
@@ -9,7 +9,8 @@
          interstitialAdUnitId:(NSString *)interstitialAdUnitId
                nativeAdUnitId:(NSString *)nativeAdUnitId
          nativeBannerAdUnitId:(NSString *)nativeBannerAdUnitId
-             rewardedAdUnitId:(NSString *)rewardedAdUnitId {
+             rewardedAdUnitId:(NSString *)rewardedAdUnitId
+              appOpenAdUnitId:(NSString *)appOpenAdUnitId {
     
     self = [super init];
     if (self) {
@@ -21,6 +22,7 @@
         _nativeAdUnitId = [nativeAdUnitId copy];
         _nativeBannerAdUnitId = [nativeBannerAdUnitId copy];
         _rewardedAdUnitId = [rewardedAdUnitId copy];
+        _appOpenAdUnitId = [appOpenAdUnitId copy];
     }
     return self;
 }
@@ -66,7 +68,9 @@
             interstitialAdUnitId:overrideOrDefault(@"DemoApp.InterstitialAdUnitId", @"SKva576GixtRW5DL_jS_D")
             nativeAdUnitId:overrideOrDefault(@"DemoApp.NativeAdUnitId", @"5NN7ZlBorm4ZoRkL6bsz9")
             nativeBannerAdUnitId:overrideOrDefault(@"DemoApp.NativeBannerAdUnitId", @"-2_Lw2b4QTlu7x6tKZ6Ww")
-            rewardedAdUnitId:overrideOrDefault(@"DemoApp.RewardedAdUnitId", @"jKOcqM-eHbGBwg76RQmsA")];
+            rewardedAdUnitId:overrideOrDefault(@"DemoApp.RewardedAdUnitId", @"jKOcqM-eHbGBwg76RQmsA")
+            // gw-admob-appopen — the permanent Google Waterfall app-open unit the QA fleet pins.
+            appOpenAdUnitId:overrideOrDefault(@"DemoApp.AppOpenAdUnitId", @"cRjP5EAPNyIOKMFG3u2YE")];
     }
     return self;
 }

--- a/demo-app-objc/CloudXObjCRemotePods/Views/Ad/AdDemoTabViewController.m
+++ b/demo-app-objc/CloudXObjCRemotePods/Views/Ad/AdDemoTabViewController.m
@@ -3,6 +3,7 @@
 #import "BannerViewController.h"
 #import "InterstitialViewController.h"
 #import "RewardedViewController.h"
+#import "AppOpenViewController.h"
 #import "MRECViewController.h"
 #import "NativeMenuViewController.h"
 #import "SettingsViewController.h"
@@ -25,6 +26,9 @@
     
     RewardedViewController *rewardedVC = [[RewardedViewController alloc] init];
     rewardedVC.tabBarItem = [[UITabBarItem alloc] initWithTitle:@"Rewarded" image:[UIImage systemImageNamed:@"star"] tag:3];
+
+    AppOpenViewController *appOpenVC = [[AppOpenViewController alloc] init];
+    appOpenVC.tabBarItem = [[UITabBarItem alloc] initWithTitle:@"App Open" image:[UIImage systemImageNamed:@"app"] tag:8];
     
     MRECViewController *mrecVC = [[MRECViewController alloc] init];
     mrecVC.tabBarItem = [[UITabBarItem alloc] initWithTitle:@"MREC" image:[UIImage systemImageNamed:@"rectangle.3.group"] tag:4];
@@ -45,6 +49,7 @@
         [[UINavigationController alloc] initWithRootViewController:bannerVC],
         [[UINavigationController alloc] initWithRootViewController:interstitialVC],
         [[UINavigationController alloc] initWithRootViewController:rewardedVC],
+        [[UINavigationController alloc] initWithRootViewController:appOpenVC],
         [[UINavigationController alloc] initWithRootViewController:mrecVC],
         [[UINavigationController alloc] initWithRootViewController:nativeVC],
         [[UINavigationController alloc] initWithRootViewController:keyValueVC],

--- a/demo-app-objc/CloudXObjCRemotePods/Views/Ad/AppOpenViewController.h
+++ b/demo-app-objc/CloudXObjCRemotePods/Views/Ad/AppOpenViewController.h
@@ -1,0 +1,11 @@
+#import "BaseAdViewController.h"
+#import <UIKit/UIKit.h>
+#import <CloudXCore/CloudXCore.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface AppOpenViewController : BaseAdViewController <CLXAppOpenDelegate, CLXAdRevenueDelegate>
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/demo-app-objc/CloudXObjCRemotePods/Views/Ad/AppOpenViewController.m
+++ b/demo-app-objc/CloudXObjCRemotePods/Views/Ad/AppOpenViewController.m
@@ -1,0 +1,231 @@
+#import "AppOpenViewController.h"
+#import <CloudXCore/CloudXCore.h>
+#import "DemoAppLogger.h"
+#import "CLXDemoConfigManager.h"
+#import "NSError+DemoDescription.h"
+
+@interface AppOpenViewController ()
+@property (nonatomic, strong) CLXAppOpen *appOpenAd;
+@property (nonatomic, assign) BOOL showAdWhenLoaded;
+@end
+
+@implementation AppOpenViewController
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+
+    // Create a vertical stack for buttons
+    UIStackView *buttonStack = [[UIStackView alloc] init];
+    buttonStack.axis = UILayoutConstraintAxisVertical;
+    buttonStack.spacing = 16;
+    buttonStack.alignment = UIStackViewAlignmentCenter;
+    buttonStack.translatesAutoresizingMaskIntoConstraints = NO;
+    [self.view addSubview:buttonStack];
+
+    // Load App Open button
+    UIButton *loadButton = [UIButton buttonWithType:UIButtonTypeSystem];
+    [loadButton setTitle:@"Load App Open" forState:UIControlStateNormal];
+    [loadButton addTarget:self action:@selector(loadAppOpenAd) forControlEvents:UIControlEventTouchUpInside];
+    loadButton.backgroundColor = [UIColor systemGreenColor];
+    [loadButton setTitleColor:[UIColor whiteColor] forState:UIControlStateNormal];
+    loadButton.titleLabel.font = [UIFont boldSystemFontOfSize:16];
+    loadButton.layer.cornerRadius = 8;
+    loadButton.translatesAutoresizingMaskIntoConstraints = NO;
+    [buttonStack addArrangedSubview:loadButton];
+
+    // Show App Open button
+    UIButton *showButton = [UIButton buttonWithType:UIButtonTypeSystem];
+    [showButton setTitle:@"Show App Open" forState:UIControlStateNormal];
+    [showButton addTarget:self action:@selector(showAppOpenAd) forControlEvents:UIControlEventTouchUpInside];
+    showButton.backgroundColor = [UIColor systemBlueColor];
+    [showButton setTitleColor:[UIColor whiteColor] forState:UIControlStateNormal];
+    showButton.titleLabel.font = [UIFont boldSystemFontOfSize:16];
+    showButton.layer.cornerRadius = 8;
+    showButton.translatesAutoresizingMaskIntoConstraints = NO;
+    [buttonStack addArrangedSubview:showButton];
+
+    // Button constraints
+    [NSLayoutConstraint activateConstraints:@[
+        [buttonStack.centerXAnchor constraintEqualToAnchor:self.view.centerXAnchor],
+        [buttonStack.topAnchor constraintEqualToAnchor:self.view.safeAreaLayoutGuide.topAnchor constant:220],
+        [loadButton.widthAnchor constraintEqualToConstant:200],
+        [loadButton.heightAnchor constraintEqualToConstant:44],
+        [showButton.widthAnchor constraintEqualToConstant:200],
+        [showButton.heightAnchor constraintEqualToConstant:44]
+    ]];
+}
+
+- (void)viewWillAppear:(BOOL)animated {
+    [super viewWillAppear:animated];
+    // No auto-loading - user must press Load App Open button
+}
+
+- (void)viewWillDisappear:(BOOL)animated {
+    [super viewWillDisappear:animated];
+    // Skip cleanup when a fullscreen ad is presented on top — the ad object must
+    // stay alive to receive show/click/close delegate callbacks. On a tab switch
+    // presentedViewController is nil, so cleanup proceeds normally.
+    if (!self.presentedViewController) {
+        [self resetAdState];
+    }
+}
+
+- (void)dealloc {
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
+}
+
+- (NSString *)adUnitId {
+    return [[CLXDemoConfigManager sharedManager] currentConfig].appOpenAdUnitId;
+}
+
+- (void)loadAppOpenAd {
+    self.receivedCallbacks = AdCallbackEventNone;
+    if (self.isLoading) {
+        [self showAlertWithTitle:@"Info" message:@"App Open is already loading."];
+        return;
+    }
+
+    if (self.appOpenAd) {
+        [self showAlertWithTitle:@"Info" message:@"App Open already loaded. Use Show App Open to display it."];
+        return;
+    }
+
+    [self loadAppOpen];
+}
+
+- (void)loadAppOpen {
+
+    if (self.isLoading || self.appOpenAd) {
+        return;
+    }
+
+    self.isLoading = YES;
+    [self updateStatusUIWithState:AdStateLoading];
+
+    NSString *adUnitId = [self adUnitId];
+
+    self.appOpenAd = [[CloudXCore shared] createAppOpenWithAdUnitId:adUnitId];
+    self.appOpenAd.delegate = self;
+    self.appOpenAd.revenueDelegate = self;
+
+    if (self.appOpenAd) {
+        [self.appOpenAd load];
+    } else {
+        self.isLoading = NO;
+        [self updateStatusUIWithState:AdStateNoAd];
+        [self showAlertWithTitle:@"Error" message:@"Failed to create app open."];
+    }
+}
+
+
+- (void)showAppOpenAd {
+
+    if (!self.appOpenAd) {
+        [self showAlertWithTitle:@"Error" message:@"No app open loaded. Please load an app open first."];
+        return;
+    }
+
+    if (self.isLoading) {
+        [self showAlertWithTitle:@"Info" message:@"App Open is still loading. Please wait."];
+        return;
+    }
+
+    if (self.appOpenAd.isReady) {
+        [self.appOpenAd showFromViewController:self
+                                    placement:@"demo_app_open"
+                                   customData:@"level:5,coins:100"];
+    } else {
+        [self showAlertWithTitle:@"Error" message:@"App Open is not ready. Please try loading again."];
+    }
+}
+
+- (void)resetAdState {
+    // CRITICAL: Call destroy before releasing to clean up WebViews and prevent zombie WebProcess
+    if (self.appOpenAd) {
+        [self.appOpenAd destroy];
+    }
+    self.appOpenAd = nil;
+    self.isLoading = NO;
+    self.showAdWhenLoaded = NO;
+    self.receivedCallbacks = AdCallbackEventNone;
+    [self updateStatusUIWithState:AdStateNoAd];
+}
+
+#pragma mark - CLXAppOpenDelegate
+
+- (void)didLoadAd:(CLXAd *)ad {
+    [[DemoAppLogger sharedInstance] logAdEvent:@"✅ AppOpen didLoadAd" ad:ad];
+    self.isLoading = NO;
+    self.receivedCallbacks |= AdCallbackEventLoaded;
+    [self updateStatusUIWithState:AdStateReady];
+}
+
+- (void)didFailToLoadAd:(NSString *)adUnitId error:(CLXError *)error {
+    // No ad object exists on failure, so use logMessage instead of logAdEvent
+    [[DemoAppLogger sharedInstance] logMessage:[NSString stringWithFormat:@"❌ AppOpen failed to load (%@) - Error: %@", adUnitId, error ? error.localizedDescription : @"Unknown error"]];
+    self.isLoading = NO;
+    [self updateStatusUIWithState:AdStateNoAd];
+
+    dispatch_async(dispatch_get_main_queue(), ^{
+        NSString *errorMessage = error ? [error detailedDemoDescription] : @"Unknown error occurred";
+        [self showAlertWithTitle:@"App Open Ad Load Failed" message:errorMessage];
+        // CRITICAL: Call destroy to clean up any partial state (including WebViews)
+        if (self.appOpenAd) {
+            [self.appOpenAd destroy];
+        }
+        self.appOpenAd = nil;
+    });
+}
+
+- (void)didDisplayAd:(CLXAd *)ad {
+    self.receivedCallbacks |= AdCallbackEventDisplayed;
+    [[DemoAppLogger sharedInstance] logAdEvent:@"👀 AppOpen didDisplayAd" ad:ad];
+}
+
+- (void)didFailToDisplayAd:(CLXAd *)ad error:(CLXError *)error {
+    [[DemoAppLogger sharedInstance] logAdEvent:@"❌ AppOpen didFailToDisplayAd" ad:ad];
+    self.isLoading = NO;
+    [self updateStatusUIWithState:AdStateNoAd];
+
+    dispatch_async(dispatch_get_main_queue(), ^{
+        // CRITICAL: Call destroy before releasing to clean up WebViews
+        if (self.appOpenAd) {
+            [self.appOpenAd destroy];
+        }
+        self.appOpenAd = nil;
+        NSString *errorMessage = error ? [error detailedDemoDescription] : @"Unknown error occurred";
+        [self showAlertWithTitle:@"App Open Ad Show Failed" message:errorMessage];
+    });
+}
+
+- (void)didHideAd:(CLXAd *)ad {
+    self.receivedCallbacks |= AdCallbackEventHidden;
+    [[DemoAppLogger sharedInstance] logAdEvent:@"🔚 AppOpen didHideAd" ad:ad];
+
+    self.showAdWhenLoaded = NO;
+
+    // CRITICAL: Call destroy to ensure full cleanup even after successful close
+    if (self.appOpenAd) {
+        [self.appOpenAd destroy];
+    }
+    self.appOpenAd = nil;
+
+    // Don't auto-load - user must press Load App Open button
+    [self updateStatusUIWithState:AdStateNoAd];
+}
+
+- (void)didClickAd:(CLXAd *)ad {
+    self.receivedCallbacks |= AdCallbackEventClicked;
+    [[DemoAppLogger sharedInstance] logAdEvent:@"👆 AppOpen didClickAd" ad:ad];
+}
+
+- (void)didRecordImpressionForAd:(CLXAd *)ad {
+    [[DemoAppLogger sharedInstance] logAdEvent:@"👁️ AppOpen didRecordImpressionForAd" ad:ad];
+}
+
+- (void)didPayRevenueForAd:(CLXAd *)ad {
+    self.receivedCallbacks |= AdCallbackEventRevenueReceived;
+    [[DemoAppLogger sharedInstance] logAdEvent:@"💰 AppOpen didPayRevenueForAd" ad:ad];
+}
+
+@end

--- a/demo-app-objc/Podfile
+++ b/demo-app-objc/Podfile
@@ -3,7 +3,10 @@ platform :ios, '13.0'
 target 'CloudXObjCRemotePods' do
   use_frameworks! :linkage => :static
 
-  pod 'CloudXCore', :path => '../core'
+  # The published 3.8.0 binary, resolved through this repo's podspec (its vendored
+  # xcframework path is repo-root-relative, so a bare :path => '../core' resolves to
+  # core/core/… and yields an empty pod).
+  pod 'CloudXCore', :podspec => '../core/CloudXCore.podspec'
   pod 'CloudXMetaAdapter', '~> 6.21.1.0'
   pod 'CloudXVungleAdapter', '~> 7.7.4.0'
   pod 'CloudXInMobiAdapter', '~> 11.4.1.0'

--- a/demo-app-objc/Podfile.lock
+++ b/demo-app-objc/Podfile.lock
@@ -131,7 +131,7 @@ PODS:
   - VungleAds (7.7.4)
 
 DEPENDENCIES:
-  - CloudXCore (from `../core`)
+  - CloudXCore (from `../core/CloudXCore.podspec`)
   - CloudXDigitalTurbineAdapter (~> 8.4.8.0)
   - CloudXGoogleWaterfallAdapter (~> 13.6.0.0)
   - CloudXInMobiAdapter (~> 11.4.1.0)
@@ -180,7 +180,7 @@ SPEC REPOS:
 
 EXTERNAL SOURCES:
   CloudXCore:
-    :path: "../core"
+    :podspec: "../core/CloudXCore.podspec"
 
 SPEC CHECKSUMS:
   Ads-Global: c4da8b23232e80b87ac55964da167ba589502f6b
@@ -214,6 +214,6 @@ SPEC CHECKSUMS:
   UnityCoherenceLib: d9be08c5b9c2880cb220c7ecd643f97ebda422b7
   VungleAds: 77bad219e9e4b34bf43ab2518bf2fac72b86100b
 
-PODFILE CHECKSUM: 8ebb1f6dd63c3f01dbbf2d2ab1dfd5e07f34f480
+PODFILE CHECKSUM: c706bfb92fe782d2183e69252446a7dfd1f2f4eb
 
 COCOAPODS: 1.17.0

--- a/demo-app-swift/CloudXSwiftRemotePods.xcodeproj/project.pbxproj
+++ b/demo-app-swift/CloudXSwiftRemotePods.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		4DD876C55EFDF951921746DA /* Pods_CloudXSwiftRemotePodsTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 210995F64F6CE9E1CA99FA0D /* Pods_CloudXSwiftRemotePodsTests.framework */; };
 		5CEBE496246CB7F22175D1DB /* Pods_CloudXSwiftRemotePods.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 969E6A13E4870F468B2C97C1 /* Pods_CloudXSwiftRemotePods.framework */; };
+		8F28481B9A4024A5F3419F7B /* AppOpenViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 599930454535954FAA090DEE /* AppOpenViewController.swift */; };
 		E3E890ABF9A350BD9F41DF81 /* Pods_CloudXSwiftRemotePods_CloudXSwiftRemotePodsUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 30A83812C9F200636B4CBF27 /* Pods_CloudXSwiftRemotePods_CloudXSwiftRemotePodsUITests.framework */; };
 /* End PBXBuildFile section */
 
@@ -40,6 +41,7 @@
 		277FC88C6CF1AD307FFEBBF4 /* Pods-CloudXSwiftRemotePods.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CloudXSwiftRemotePods.debug.xcconfig"; path = "Target Support Files/Pods-CloudXSwiftRemotePods/Pods-CloudXSwiftRemotePods.debug.xcconfig"; sourceTree = "<group>"; };
 		30A83812C9F200636B4CBF27 /* Pods_CloudXSwiftRemotePods_CloudXSwiftRemotePodsUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_CloudXSwiftRemotePods_CloudXSwiftRemotePodsUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3976EB4F4BF62B6D5539BE6A /* Pods-CloudXSwiftRemotePods-CloudXSwiftRemotePodsUITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CloudXSwiftRemotePods-CloudXSwiftRemotePodsUITests.release.xcconfig"; path = "Target Support Files/Pods-CloudXSwiftRemotePods-CloudXSwiftRemotePodsUITests/Pods-CloudXSwiftRemotePods-CloudXSwiftRemotePodsUITests.release.xcconfig"; sourceTree = "<group>"; };
+		599930454535954FAA090DEE /* AppOpenViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppOpenViewController.swift; sourceTree = "<group>"; };
 		969E6A13E4870F468B2C97C1 /* Pods_CloudXSwiftRemotePods.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_CloudXSwiftRemotePods.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B86BF64856422458B376B338 /* Pods-CloudXSwiftRemotePods-CloudXSwiftRemotePodsUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CloudXSwiftRemotePods-CloudXSwiftRemotePodsUITests.debug.xcconfig"; path = "Target Support Files/Pods-CloudXSwiftRemotePods-CloudXSwiftRemotePodsUITests/Pods-CloudXSwiftRemotePods-CloudXSwiftRemotePodsUITests.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -133,6 +135,7 @@
 		3C2CBF88E844070AD78FADE4 /* ManualFiles */ = {
 			isa = PBXGroup;
 			children = (
+				94C20E42ABC8C117F29C8465 /* Views */,
 			);
 			name = ManualFiles;
 			path = CloudXSwiftRemotePods;
@@ -148,6 +151,15 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
+		94C20E42ABC8C117F29C8465 /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				FA77BA1CA5FF4345F2695DE9 /* Ad */,
+			);
+			name = Views;
+			path = Views;
+			sourceTree = "<group>";
+		};
 		E1698230A3F518F2A8E30456 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
@@ -159,6 +171,15 @@
 				1917BCDE38ECEECE4237054E /* Pods-CloudXSwiftRemotePodsTests.release.xcconfig */,
 			);
 			path = Pods;
+			sourceTree = "<group>";
+		};
+		FA77BA1CA5FF4345F2695DE9 /* Ad */ = {
+			isa = PBXGroup;
+			children = (
+				599930454535954FAA090DEE /* AppOpenViewController.swift */,
+			);
+			name = Ad;
+			path = Ad;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -443,6 +464,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				8F28481B9A4024A5F3419F7B /* AppOpenViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/demo-app-swift/CloudXSwiftRemotePods/Configuration/CLXDemoConfigManager.swift
+++ b/demo-app-swift/CloudXSwiftRemotePods/Configuration/CLXDemoConfigManager.swift
@@ -9,6 +9,7 @@ class CLXDemoConfig {
     let nativeAdUnitId: String
     let nativeBannerAdUnitId: String
     let rewardedAdUnitId: String
+    let appOpenAdUnitId: String
     
     init(appKey: String,
          hashedUserId: String,
@@ -17,7 +18,8 @@ class CLXDemoConfig {
          interstitialAdUnitId: String,
          nativeAdUnitId: String,
          nativeBannerAdUnitId: String,
-         rewardedAdUnitId: String) {
+         rewardedAdUnitId: String,
+         appOpenAdUnitId: String) {
         
         self.appKey = appKey
         self.hashedUserId = hashedUserId
@@ -27,6 +29,7 @@ class CLXDemoConfig {
         self.nativeAdUnitId = nativeAdUnitId
         self.nativeBannerAdUnitId = nativeBannerAdUnitId
         self.rewardedAdUnitId = rewardedAdUnitId
+        self.appOpenAdUnitId = appOpenAdUnitId
     }
 }
 
@@ -60,7 +63,9 @@ class CLXDemoConfigManager {
             interstitialAdUnitId: overrideOrDefault("DemoApp.InterstitialAdUnitId", "SKva576GixtRW5DL_jS_D"),
             nativeAdUnitId: overrideOrDefault("DemoApp.NativeAdUnitId", "5NN7ZlBorm4ZoRkL6bsz9"),
             nativeBannerAdUnitId: overrideOrDefault("DemoApp.NativeBannerAdUnitId", "-2_Lw2b4QTlu7x6tKZ6Ww"),
-            rewardedAdUnitId: overrideOrDefault("DemoApp.RewardedAdUnitId", "jKOcqM-eHbGBwg76RQmsA")
+            rewardedAdUnitId: overrideOrDefault("DemoApp.RewardedAdUnitId", "jKOcqM-eHbGBwg76RQmsA"),
+            // gw-admob-appopen — the permanent Google Waterfall app-open unit the QA fleet pins.
+            appOpenAdUnitId: overrideOrDefault("DemoApp.AppOpenAdUnitId", "cRjP5EAPNyIOKMFG3u2YE")
         )
     }
 }

--- a/demo-app-swift/CloudXSwiftRemotePods/DeepLinkRouter.swift
+++ b/demo-app-swift/CloudXSwiftRemotePods/DeepLinkRouter.swift
@@ -12,6 +12,7 @@ enum DeepLinkRouter {
         "mrec":                  "MRECViewController",
         "interstitial":          "InterstitialViewController",
         "rewarded":              "RewardedViewController",
+        "app-open":              "AppOpenViewController",
         "native":                "NativeMenuViewController",
     ]
 
@@ -67,11 +68,11 @@ private final class Adapter: NSObject, CLXTestHarnessApp {
     // MARK: - Format Configuration
 
     func supportedFormats() -> [String] {
-        ["banner", "mrec", "interstitial", "rewarded", "native"]
+        ["banner", "mrec", "interstitial", "app-open", "rewarded", "native"]
     }
 
     func isFullscreenFormat(_ format: String) -> Bool {
-        format == "interstitial" || format == "rewarded"
+        format == "interstitial" || format == "app-open" || format == "rewarded"
     }
 
     func loadSelector(forFormat format: String) -> Selector? {
@@ -80,6 +81,7 @@ private final class Adapter: NSObject, CLXTestHarnessApp {
         case "mrec":                  return NSSelectorFromString("loadMRECAd")
         case "interstitial":          return NSSelectorFromString("loadInterstitialAd")
         case "rewarded":              return NSSelectorFromString("loadRewardedAd")
+        case "app-open":              return NSSelectorFromString("loadAppOpenAd")
         case "native":                return NSSelectorFromString("loadNativeAd")
         default:                      return nil
         }
@@ -89,6 +91,7 @@ private final class Adapter: NSObject, CLXTestHarnessApp {
         switch format {
         case "interstitial":          return NSSelectorFromString("showInterstitialAd")
         case "rewarded":              return NSSelectorFromString("showRewardedAd")
+        case "app-open":              return NSSelectorFromString("showAppOpenAd")
         default:                      return nil
         }
     }

--- a/demo-app-swift/CloudXSwiftRemotePods/Views/Ad/AdDemoTabViewController.swift
+++ b/demo-app-swift/CloudXSwiftRemotePods/Views/Ad/AdDemoTabViewController.swift
@@ -24,6 +24,9 @@ class AdDemoTabViewController: UITabBarController {
         
         let rewardedVC = RewardedViewController()
         rewardedVC.tabBarItem = UITabBarItem(title: "Rewarded", image: UIImage(systemName: "star"), tag: 3)
+
+        let appOpenVC = AppOpenViewController()
+        appOpenVC.tabBarItem = UITabBarItem(title: "App Open", image: UIImage(systemName: "app"), tag: 8)
         
         let mrecVC = MRECViewController()
         mrecVC.tabBarItem = UITabBarItem(title: "MREC", image: UIImage(systemName: "rectangle.3.group"), tag: 4)
@@ -43,6 +46,7 @@ class AdDemoTabViewController: UITabBarController {
             UINavigationController(rootViewController: bannerVC),
             UINavigationController(rootViewController: interstitialVC),
             UINavigationController(rootViewController: rewardedVC),
+            UINavigationController(rootViewController: appOpenVC),
             UINavigationController(rootViewController: mrecVC),
             UINavigationController(rootViewController: nativeVC),
             UINavigationController(rootViewController: keyValueVC),

--- a/demo-app-swift/CloudXSwiftRemotePods/Views/Ad/AppOpenViewController.swift
+++ b/demo-app-swift/CloudXSwiftRemotePods/Views/Ad/AppOpenViewController.swift
@@ -1,0 +1,241 @@
+import UIKit
+import CloudXCore
+
+class AppOpenViewController: BaseAdViewController {
+    private var appOpenAd: CLXAppOpen?
+    private var showAdWhenLoaded = false
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupUI()
+        setupNotifications()
+        updateStatusUI(state: AdState.noAd)
+    }
+    
+    private func setupUI() {
+        // Create a vertical stack for buttons
+        let buttonStack = UIStackView()
+        buttonStack.axis = .vertical
+        buttonStack.spacing = 16
+        buttonStack.alignment = .center
+        buttonStack.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(buttonStack)
+        
+        // Load App Open button
+        let loadButton = UIButton(type: .system)
+        loadButton.setTitle("Load App Open", for: .normal)
+        loadButton.addTarget(self, action: #selector(loadAppOpenAd), for: .touchUpInside)
+        loadButton.backgroundColor = .systemGreen
+        loadButton.setTitleColor(.white, for: .normal)
+        loadButton.titleLabel?.font = .boldSystemFont(ofSize: 16)
+        loadButton.layer.cornerRadius = 8
+        loadButton.translatesAutoresizingMaskIntoConstraints = false
+        buttonStack.addArrangedSubview(loadButton)
+        
+        // Show App Open button
+        let showButton = UIButton(type: .system)
+        showButton.setTitle("Show App Open", for: .normal)
+        showButton.addTarget(self, action: #selector(showAppOpenAd), for: .touchUpInside)
+        showButton.backgroundColor = .systemBlue
+        showButton.setTitleColor(.white, for: .normal)
+        showButton.titleLabel?.font = .boldSystemFont(ofSize: 16)
+        showButton.layer.cornerRadius = 8
+        showButton.translatesAutoresizingMaskIntoConstraints = false
+        buttonStack.addArrangedSubview(showButton)
+        
+        // Button constraints
+        NSLayoutConstraint.activate([
+            buttonStack.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            buttonStack.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 100),
+            loadButton.widthAnchor.constraint(equalToConstant: 200),
+            loadButton.heightAnchor.constraint(equalToConstant: 44),
+            showButton.widthAnchor.constraint(equalToConstant: 200),
+            showButton.heightAnchor.constraint(equalToConstant: 44)
+        ])
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        // No auto-loading - user must press Load App Open button
+    }
+    
+    @objc private func loadAppOpenAd() {
+        receivedCallbacks = []
+        
+        if isLoading {
+            showAlert(title: "Info", message: "App Open is already loading.")
+            return
+        }
+        
+        if appOpenAd != nil {
+            showAlert(title: "Info", message: "App Open already loaded. Use Show App Open to display it.")
+            return
+        }
+        
+        loadAppOpen()
+    }
+    
+    private func loadAppOpen() {
+
+        if isLoading || appOpenAd != nil {
+            return
+        }
+
+        isLoading = true
+        updateStatusUI(state: AdState.loading)
+
+        // Get ad unit ID from config manager (launch override honored in applyLaunchOverrides)
+        let adUnitId = CLXDemoConfigManager.sharedManager.currentConfig.appOpenAdUnitId
+
+        appOpenAd = cloudX.createAppOpen(adUnitId: adUnitId)
+        appOpenAd?.delegate = self
+        appOpenAd?.revenueDelegate = self
+        
+        if let appOpenAd = appOpenAd {
+            appOpenAd.load()
+        } else {
+            isLoading = false
+            updateStatusUI(state: AdState.noAd)
+            showAlert(title: "Error", message: "Failed to create app open.")
+        }
+    }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        resetAdState()
+    }
+    
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
+    
+    private enum AdState {
+        case noAd
+        case loading
+        case ready
+        
+        var text: String {
+            switch self {
+            case .noAd: return "No Ad Loaded"
+            case .loading: return "Loading Ad..."
+            case .ready: return "Ad Ready"
+            }
+        }
+        
+        var color: UIColor {
+            switch self {
+            case .noAd: return .systemRed
+            case .loading: return .systemYellow
+            case .ready: return .systemGreen
+            }
+        }
+    }
+    
+    private func updateStatusUI(state: AdState) {
+        DispatchQueue.main.async { [weak self] in
+            self?.statusLabel.text = state.text
+            self?.statusLabel.textColor = state.color
+            self?.statusIndicator.backgroundColor = state.color
+        }
+    }
+    
+    private func setupNotifications() {
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleSDKInitialized),
+            name: .sdkInitialized,
+            object: nil
+        )
+    }
+    
+    @objc private func handleSDKInitialized() {
+        // Don't auto-create - wait for user to press Load App Open button
+    }
+    
+    @objc private func showAppOpenAd() {
+        
+        guard let appOpenAd = appOpenAd else {
+            showAlert(title: "Error", message: "No app open loaded. Please load an app open first.")
+            return
+        }
+        
+        if isLoading {
+            showAlert(title: "Info", message: "App Open is still loading. Please wait.")
+            return
+        }
+        
+        if appOpenAd.isReady {
+            appOpenAd.show(from: self)
+        } else {
+            showAlert(title: "Error", message: "App Open is not ready. Please try loading again.")
+        }
+    }
+    
+    private func resetAdState() {
+        appOpenAd = nil
+        isLoading = false
+        showAdWhenLoaded = false
+        receivedCallbacks = []
+        updateStatusUI(state: AdState.noAd)
+    }
+}
+
+extension AppOpenViewController: CLXAppOpenDelegate, CLXAdRevenueDelegate {
+    func didLoad(_ ad: CLXAd) {
+        DemoAppLogger.sharedInstance.logAdEvent("✅ AppOpen didLoadAd", ad: ad)
+        isLoading = false
+        receivedCallbacks.insert(.loaded)
+        updateStatusUI(state: AdState.ready)
+        // Don't auto-show - wait for user to press Show App Open button
+    }
+    
+    func didFailToLoadAd(_ adUnitId: String, error: CLXError) {
+        // No ad object exists on failure, so use logMessage instead of logAdEvent
+        DemoAppLogger.sharedInstance.logMessage("❌ AppOpen failed to load for ad unit '\(adUnitId)' - Error: \(error.localizedDescription)")
+        isLoading = false
+        updateStatusUI(state: AdState.noAd)
+        
+        DispatchQueue.main.async { [weak self] in
+            let errorMessage = error.localizedDescription
+            self?.showAlert(title: "App Open Ad Error", message: errorMessage)
+            self?.appOpenAd = nil
+        }
+    }
+    
+    func didDisplay(_ ad: CLXAd) {
+        receivedCallbacks.insert(.displayed)
+        DemoAppLogger.sharedInstance.logAdEvent("👀 AppOpen didDisplayAd", ad: ad)
+    }
+    
+    func didFailToDisplay(_ ad: CLXAd, error: CLXError) {
+        DemoAppLogger.sharedInstance.logAdEvent("❌ AppOpen didFailToDisplayAd", ad: ad)
+        updateStatusUI(state: AdState.noAd)
+        
+        DispatchQueue.main.async { [weak self] in
+            self?.appOpenAd = nil
+            let errorMessage = error.localizedDescription
+            self?.showAlert(title: "App Open Ad Error", message: errorMessage)
+        }
+    }
+    
+    func didHide(_ ad: CLXAd) {
+        receivedCallbacks.insert(.hidden)
+        DemoAppLogger.sharedInstance.logAdEvent("🔚 AppOpen didHideAd", ad: ad)
+        
+        showAdWhenLoaded = false
+        appOpenAd = nil
+        
+        // Don't auto-load - user must press Load App Open button
+        updateStatusUI(state: AdState.noAd)
+    }
+    
+    func didClick(_ ad: CLXAd) {
+        receivedCallbacks.insert(.clicked)
+        DemoAppLogger.sharedInstance.logAdEvent("👆 AppOpen didClickAd", ad: ad)
+    }
+    
+    func didPayRevenue(for ad: CLXAd) {
+        receivedCallbacks.insert(.revenueReceived)
+        DemoAppLogger.sharedInstance.logAdEvent("💰 AppOpen didPayRevenue", ad: ad)
+    }
+} 

--- a/demo-app-swift/Podfile
+++ b/demo-app-swift/Podfile
@@ -3,7 +3,10 @@ platform :ios, '13.0'
 target 'CloudXSwiftRemotePods' do
   use_frameworks! :linkage => :static
 
-  pod 'CloudXCore', :path => '../core'
+  # The published 3.8.0 binary, resolved through this repo's podspec (its vendored
+  # xcframework path is repo-root-relative, so a bare :path => '../core' resolves to
+  # core/core/… and yields an empty pod).
+  pod 'CloudXCore', :podspec => '../core/CloudXCore.podspec'
   pod 'CloudXMetaAdapter', '~> 6.21.1.0'
   pod 'CloudXVungleAdapter', '~> 7.7.4.0'
   pod 'CloudXInMobiAdapter', '~> 11.4.1.0'

--- a/demo-app-swift/Podfile.lock
+++ b/demo-app-swift/Podfile.lock
@@ -131,7 +131,7 @@ PODS:
   - VungleAds (7.7.4)
 
 DEPENDENCIES:
-  - CloudXCore (from `../core`)
+  - CloudXCore (from `../core/CloudXCore.podspec`)
   - CloudXDigitalTurbineAdapter (~> 8.4.8.0)
   - CloudXGoogleWaterfallAdapter (~> 13.6.0.0)
   - CloudXInMobiAdapter (~> 11.4.1.0)
@@ -180,7 +180,7 @@ SPEC REPOS:
 
 EXTERNAL SOURCES:
   CloudXCore:
-    :path: "../core"
+    :podspec: "../core/CloudXCore.podspec"
 
 SPEC CHECKSUMS:
   Ads-Global: c4da8b23232e80b87ac55964da167ba589502f6b
@@ -214,6 +214,6 @@ SPEC CHECKSUMS:
   UnityCoherenceLib: d9be08c5b9c2880cb220c7ecd643f97ebda422b7
   VungleAds: 77bad219e9e4b34bf43ab2518bf2fac72b86100b
 
-PODFILE CHECKSUM: eb2943bcbebb64244f54645df0078f5880a478ff
+PODFILE CHECKSUM: cb1705b8969eca8d13b018242cdc7975a801644e
 
 COCOAPODS: 1.17.0

--- a/scripts/add-files-to-xcodeproj.rb
+++ b/scripts/add-files-to-xcodeproj.rb
@@ -1,0 +1,43 @@
+#!/usr/bin/env ruby
+# Add source files to an Xcode project target, creating groups that mirror the
+# on-disk folder path relative to the project's main group.
+#
+#   ruby scripts/add-files-to-xcodeproj.rb <project.xcodeproj> <target> <file> [file...]
+#
+# Idempotent: files already referenced are skipped. .m/.swift/.mm go into the
+# Sources build phase; .h is reference-only.
+require 'xcodeproj'
+
+project_path, target_name, *files = ARGV
+abort "usage: #{$0} <project.xcodeproj> <target> <file>..." if files.empty?
+
+project = Xcodeproj::Project.open(project_path)
+target = project.targets.find { |t| t.name == target_name } or abort "target #{target_name} not found"
+project_dir = File.dirname(File.expand_path(project_path))
+
+files.each do |file|
+  abs = File.expand_path(file)
+  rel = abs.sub("#{project_dir}/", '')
+  if project.files.any? { |f| f.real_path.to_s == abs }
+    puts "skip   #{rel} (already referenced)"
+    next
+  end
+  # Prefer the existing group whose on-disk path is the file's directory (groups
+  # may be named differently from their folder, or nest their path), so files
+  # land next to their siblings instead of in a parallel group tree.
+  dir = File.dirname(abs)
+  group = project.groups.flat_map { |g| [g] + g.recursive_children_groups }
+                 .find { |g| g.real_path.to_s == dir }
+  unless group
+    group = project.main_group
+    File.dirname(rel).split('/').each do |part|
+      next if part == '.'
+      group = group.children.find { |c| c.is_a?(Xcodeproj::Project::Object::PBXGroup) && c.real_path.to_s == File.join(group.real_path.to_s, part) } ||
+              group.new_group(part, part)
+    end
+  end
+  ref = group.new_file(abs)
+  target.add_file_references([ref]) if %w[.m .mm .swift].include?(File.extname(abs))
+  puts "added  #{rel}"
+end
+project.save


### PR DESCRIPTION
## What publishers see
- Both public demo apps gain an **App Open** tab (load / show, delegate events logged), matching the other fullscreen formats.
- The deep-link router accepts `app-open` alongside the existing formats, so the QA harness can drive app-open in the public apps.
- `DemoApp.AppOpenAdUnitId` override in both config managers; production default is the demo account's app-open unit.

## Also
- Podfiles resolve CloudXCore via `:podspec => '../core/CloudXCore.podspec'`: a bare `:path => '../core'` makes CocoaPods look for the vendored xcframework under `core/core/` and yields an empty pod.
- `scripts/add-files-to-xcodeproj.rb` — register source files in a target from the CLI (used to add the new controllers).

## Deliberately not included
The monorepo demos' test-creatives machinery (bid-response swizzler, creative test runner, expectation verifier). It depends on SDK-internal hooks and does not belong in a public repo; the renderer-creative suite keeps running on the monorepo ObjC demo. An earlier revision of this PR included it — removed.

## Verification (packaged CloudXCore 3.8.0 binary, iPhone 17 simulator, Xcode 26.6)
| Check | Result |
|---|---|
| Harness-less builds, both demos, committed Podfiles | `BUILD SUCCEEDED` × 2 |
| Swift demo, `test-runner.sh … app-open` (harness injected locally) | route dispatched; real auction on the production app-open unit; `TEST RESULT: PASS` (2026-08-27, `reports/release-3.8.0/parity-swift-appopen-v2`) |

## Heads-up (pre-existing, unrelated to this PR)
The public ObjC demo crashes after SDK init with `CloudXDigitalTurbineAdapter` 8.4.8.0+ (Fyber Marketplace SDK 8.4.8 / 8.4.9 / 8.4.10; 8.4.7 is fine). Reported to Digital Turbine in `#ext-cloudx-dt`; publisher-facing known issue is live in the docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)