### PR TITLE
CXD-3198: Add the GAM Prebid 1.0.0 changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## GAM Prebid integration 1.0.0 - 2026-08-26
+
+Install: `pod 'CloudXGAMPrebid', '~> 1.0'`
+
+### Added
+- First release, for publishers who run Google Ad Manager as their primary ad server. Run a CloudX auction, attach the returned key-values to your own GAM request, and let GAM decide. Banner, MREC, interstitial, rewarded and native are supported.
+- Requires CloudXCore >= 3.8.0 and Google Mobile Ads SDK 13.x (`~> 13.0`). GMA is weak-linked — your app supplies and initializes it, and the pod is never bundled with a copy.
+- Calling `notifyGamResponse:` on every GAM load success and `notifyGamRequestFailed` on every failure is required. Skip either and the auction settles on its TTL as an expiry, losing the real outcome and the GAM response id that joins it to your Ad Manager reporting.
+- A GAM load that resolves to a different ad no longer tears down the creative GAM is still displaying, and a loss between dispatch and show no longer fails the pending fullscreen ad. Dispatch is validated before the ad is claimed (`CLXGamTokenRegistry`, `CLXGamAdFormat`).
+
+---
+
 ## MobileFuse adapter 1.11.0.1 - 2026-08-24
 
 Install: `pod 'CloudXMobileFuseAdapter', '~> 1.11.0.1'`


### PR DESCRIPTION
## Summary

Public changelog entry for the first `CloudXGAMPrebid` release, ahead of the 1.0.0 tag.

Covers what a publisher integrating the pod needs: what it does, the CloudXCore and Google Mobile Ads floors it requires, that GMA is weak-linked so their own copy satisfies it, and that the notify calls are required rather than optional — skipping one settles the auction as a TTL expiry and loses both the real outcome and the GAM response id that joins it to Ad Manager reporting.

The last bullet names `CLXGamTokenRegistry` and `CLXGamAdFormat`. Both are installed public headers, and the changelog-coverage gate requires the release to describe them, so the bullet leads with the behaviour a publisher actually sees — a GAM load resolving to a different ad no longer tears down the creative GAM is displaying — and names the classes once at the end rather than making them the subject.

## Validation

- The shared brevity gate passes: every bullet is inside the 300-character cap.
- `publish-adapter-release.sh gam-prebid --dry-run` in the private repo runs the coverage and style gates against this file and passes.
