### PR TITLE
Point CHANGELOG.md at the docs changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 # CloudX iOS SDK Changelog
 
-All notable changes to the CloudX iOS SDK will be documented in this file.
+Release notes live at https://docs.cloudx.io/en/ios/changelog.
+Adapter release notes live on each adapter page under https://docs.cloudx.io/en/ios/adapters.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+---
+
+Entries below this line are historical and no longer updated.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # CloudX iOS SDK Changelog
 
 Release notes live at https://docs.cloudx.io/en/ios/changelog.
-Adapter release notes live on each adapter page under https://docs.cloudx.io/en/ios/adapters.
+Adapter release notes live on each adapter page, linked from https://docs.cloudx.io/en/ios/integration.
 
 ---
 


### PR DESCRIPTION
This file has been a hand-maintained copy of the docs site changelog. We are aligning the iOS release flow with Android, where the docs page is the only public copy, so the release scripts in the mobile repo stop reading and gating this file. This PR replaces the header with links to the docs changelog and the integration page (which links every adapter page), and freezes the existing history below a rule. Nothing at or after the first release heading changes.

## Dependencies

Merge after the mobile PR that removes this file from the iOS publish gates: https://github.com/cloudx-io/mobile/pull/613. Landing this first would leave the old scripts gating a file whose body says it is no longer updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
