### PR TITLE
Point the public demo apps at CloudXCore 3.9.0

### DIFF
--- a/demo-app-objc/Podfile.lock
+++ b/demo-app-objc/Podfile.lock
@@ -6,7 +6,7 @@ PODS:
     - Ads-Global/TikTokBusinessSDK
   - Ads-Global/PangleSDK (8.2.0.7)
   - Ads-Global/TikTokBusinessSDK (8.2.0.7)
-  - CloudXCore (3.8.0)
+  - CloudXCore (3.9.0)
   - CloudXDigitalTurbineAdapter (8.4.8.0):
     - CloudXCore (>= 3.5.0)
     - Fyber_Marketplace_SDK (= 8.4.8)
@@ -184,7 +184,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Ads-Global: c4da8b23232e80b87ac55964da167ba589502f6b
-  CloudXCore: 6ef15e3b6cc62ad445e220c46897c21758a2ab35
+  CloudXCore: a6479247b499278e66faaf05a8cdb6f8fec3a1ee
   CloudXDigitalTurbineAdapter: 0c37b4f298913b3a5611ef1f6a65aa50bd4bb9a9
   CloudXGoogleWaterfallAdapter: e2326c444c3a1879b17b0d28f32ca0b453e172b9
   CloudXInMobiAdapter: 280563b1b05dc9f5efbc6ca9d4a25d71b8fd24a8

--- a/demo-app-swift/Podfile.lock
+++ b/demo-app-swift/Podfile.lock
@@ -6,7 +6,7 @@ PODS:
     - Ads-Global/TikTokBusinessSDK
   - Ads-Global/PangleSDK (8.2.0.7)
   - Ads-Global/TikTokBusinessSDK (8.2.0.7)
-  - CloudXCore (3.8.0)
+  - CloudXCore (3.9.0)
   - CloudXDigitalTurbineAdapter (8.4.8.0):
     - CloudXCore (>= 3.5.0)
     - Fyber_Marketplace_SDK (= 8.4.8)
@@ -184,7 +184,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Ads-Global: c4da8b23232e80b87ac55964da167ba589502f6b
-  CloudXCore: 6ef15e3b6cc62ad445e220c46897c21758a2ab35
+  CloudXCore: a6479247b499278e66faaf05a8cdb6f8fec3a1ee
   CloudXDigitalTurbineAdapter: 0c37b4f298913b3a5611ef1f6a65aa50bd4bb9a9
   CloudXGoogleWaterfallAdapter: e2326c444c3a1879b17b0d28f32ca0b453e172b9
   CloudXInMobiAdapter: 280563b1b05dc9f5efbc6ca9d4a25d71b8fd24a8


### PR DESCRIPTION
## What this fixes

Both public demo `Podfile.lock` files still resolved **CloudXCore 3.8.0**. They consume the local podspec (`:podspec => '../core/CloudXCore.podspec'`), which is already at 3.9.0 — so the locks were simply stale, not deliberately pinned.

Caught by the release checkpoint chain, which is what it's for:

```
[FAIL] demo-app-objc/Podfile.lock shows CloudXCore 3.8.0, expected 3.9.0
[FAIL] demo-app-swift/Podfile.lock shows CloudXCore 3.8.0, expected 3.9.0
```

These are the publisher-facing integration examples. Shipping 3.9.0 with the demos wired to 3.8.0 would misrepresent the release to anyone using them as a reference.

## How

`pod update CloudXCore --no-repo-update` in each app — which is what CocoaPods itself recommended when plain `pod install` refused the changed local podspec version:

> *"It seems like you've changed the version of the dependency `CloudXCore`… You should run `pod update CloudXCore --no-repo-update` to apply changes made locally."*

| App | Before | After |
|---|---|---|
| `demo-app-objc` | 3.8.0 | **3.9.0** |
| `demo-app-swift` | 3.8.0 | **3.9.0** |

Only the two lockfiles change.

## Release context

Last blocker before `pod trunk push`. Already green: gate passed (run [34524627056](https://github.com/cloudx-io/mobile/actions/runs/34524627056)), `Release artifact provenance verified` against merged `main`, tags repointed at the verified commits, and checkpoints `phase-1`, `phase-2a`, `phase-2b` recorded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)